### PR TITLE
test-b moved to nyc3, scale to c8, scale volume to 1100

### DIFF
--- a/resources/aries-test-b/droplets.tf
+++ b/resources/aries-test-b/droplets.tf
@@ -1,8 +1,8 @@
 resource "digitalocean_droplet" "aries-test-b-nodes-farmer-relayer" {
   image  = "ubuntu-20-04-x64"
-  name   = "aries-test-nodes-farmer-relayer-b-16112021"
-  region = "sfo3"
-  size   = "s-4vcpu-8gb"
+  name   = "aries-test-b-nodes-farmer-relayer"
+  region = "nyc3"
+  size   = "c-8"
   ssh_keys = [
     data.digitalocean_ssh_key.nazar-key.id,
     data.digitalocean_ssh_key.serge-key.id,

--- a/resources/aries-test-b/volumes.tf
+++ b/resources/aries-test-b/volumes.tf
@@ -1,9 +1,9 @@
 resource "digitalocean_volume" "aries-test-b-volume" {
-  region                  = "sfo3"
-  name                    = "aries-test-relayer-data-b"
-  size                    = 400
+  region                  = "nyc3"
+  name                    = "aries-test-b-volume"
+  size                    = 1100
   initial_filesystem_type = "ext4"
-  description             = "Extra volume for relayer data initial imports."
+  description             = "Extra volume for aries test b."
 }
 
 resource "digitalocean_volume_attachment" "aries-test-b-volume" {


### PR DESCRIPTION
# Description.

- Will close : #15 

- scale droplet and volume
- move to nyc3
- update names and descriptions with same as test-a

Note: `test-rpc` public dns is using `test-a` now. `test-b` is safe to be modified.