### PR TITLE
Move dev to nyc

### DIFF
--- a/resources/aries-dev/droplets.tf
+++ b/resources/aries-dev/droplets.tf
@@ -1,7 +1,7 @@
 resource "digitalocean_droplet" "aries-dev-nodes-farmer-relayer" {
   image  = "ubuntu-20-04-x64"
   name   = "aries-dev-nodes-farmer-relayer"
-  region = "sfo3"
+  region = "nyc3"
   size   = "c-8"
   ssh_keys = [
     data.digitalocean_ssh_key.nazar-key.id,

--- a/resources/aries-dev/volumes.tf
+++ b/resources/aries-dev/volumes.tf
@@ -1,13 +1,13 @@
 # DEVELOPMENT
-resource "digitalocean_volume" "aries-dev-relayer-volume" {
+resource "digitalocean_volume" "aries-dev-volume" {
   region                  = "nyc3"
-  name                    = "aries-dev-relayer-volume"
+  name                    = "aries-dev-volume"
   size                    = 1100
   initial_filesystem_type = "ext4"
-  description             = "Extra volume for relayer data initial imports."
+  description             = "Extra volume for aries dev."
 }
 
-resource "digitalocean_volume_attachment" "aries-dev-relayer-volume" {
+resource "digitalocean_volume_attachment" "aries-dev-volume" {
   droplet_id = digitalocean_droplet.aries-dev-nodes-farmer-relayer.id
-  volume_id  = digitalocean_volume.aries-dev-relayer-volume.id
+  volume_id  = digitalocean_volume.aries-dev-volume.id
 }

--- a/resources/aries-dev/volumes.tf
+++ b/resources/aries-dev/volumes.tf
@@ -1,6 +1,6 @@
 # DEVELOPMENT
 resource "digitalocean_volume" "aries-dev-relayer-volume" {
-  region                  = "sfo3"
+  region                  = "nyc3"
   name                    = "aries-dev-relayer-volume"
   size                    = 1100
   initial_filesystem_type = "ext4"


### PR DESCRIPTION
Updates to move Dev env to NYC3.

Note: this will not remove the old SFO project as got this issue under investigation.
