### PR TITLE
Expose gateway service port

### DIFF
--- a/_docs/7_SubsquidArchive/docker-compose.yml
+++ b/_docs/7_SubsquidArchive/docker-compose.yml
@@ -34,6 +34,8 @@ services:
        "--database-url", "postgres://postgres:postgres@db:5432/squid-archive",
        "--database-max-connections", "3", # max number of concurrent database connections
     ]
+    ports:
+      - "8888:8000"
 
   # Explorer service is optional.
   # It provides rich GraphQL API for querying archived data.


### PR DESCRIPTION
We need to expose this port for Squids, the `explorer` service does not work for this purpose 