### PR TITLE
Subsquid archive: add Nginx and SSL section

### DIFF
--- a/_docs/7_SubsquidArchive/README.md
+++ b/_docs/7_SubsquidArchive/README.md
@@ -31,3 +31,26 @@ Pull fresh images and start containers:
 docker-compose pull
 docker-compose up -d
 ```
+
+## Nginx setup and SSL certificate
+Install Nginx:
+```bash
+sudo apt update
+sudo apt install nginx
+```
+
+Sample [Nginx config](archive.subspace.network) can be used as a reference.
+
+Install Certbot:
+```bash
+sudo snap install core
+sudo snap refresh core
+sudo apt remove certbot
+sudo snap install --classic certbot
+sudo ln -s /snap/bin/certbot /usr/bin/certbot
+```
+
+Obtain an SSL certificate:
+```bash
+sudo certbot --nginx -d archive.subspace.network
+```

--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -1,0 +1,44 @@
+server {
+    root /var/www/arhive.subspace.network/html;
+    index index.html index.htm index.nginx-debian.html;
+
+    server_name archive.subspace.network;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location /graphql {
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:8888/graphql;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/archive.subspace.network/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/archive.subspace.network/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+server {
+    if ($host = archive.subspace.network) {
+        return 301 https://$host$request_uri;
+        } # managed by Certbot
+
+
+        listen 80;
+        listen [::]:80;
+
+        server_name archive.subspace.network;
+        return 404; # managed by Certbot
+
+
+    }

--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -31,14 +31,12 @@ server {
 server {
     if ($host = archive.subspace.network) {
         return 301 https://$host$request_uri;
-        } # managed by Certbot
+    } # managed by Certbot
 
 
-        listen 80;
-        listen [::]:80;
+    listen 80;
+    listen [::]:80;
 
-        server_name archive.subspace.network;
-        return 404; # managed by Certbot
-
-
-    }
+    server_name archive.subspace.network;
+    return 404; # managed by Certbot
+}


### PR DESCRIPTION
Archive is already available on `https://archive.subspace.network/graphql`, can be tested with this curl:
```
curl --location --request POST 'https://archive.subspace.network/graphql' \
--header 'Content-Type: application/json' \
--data-raw '{"query":"query { status { head } }"}'
```

Closes #60 