### PR TITLE
Add GraphQL explorer to Nginx

### DIFF
--- a/_docs/7_SubsquidArchive/README.md
+++ b/_docs/7_SubsquidArchive/README.md
@@ -40,6 +40,9 @@ sudo apt install nginx
 ```
 
 Sample [Nginx config](archive.subspace.network) can be used as a reference.
+> Note: it requires including `/etc/nginx/cors-settings.conf`, which can be found [here](cors-settings.conf)
+
+It exposes Archive Graphql endpoint `/api` (consumed by squids) as well as Graphql Explorer at `/graphql` (UI for exploration and debugging)
 
 Install Certbot:
 ```bash

--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -35,24 +35,4 @@ server {
         proxy_set_header Connection "upgrade";
         include /etc/nginx/cors-settings.conf;
     }
-
-    listen [::]:443 ssl ipv6only=on; # managed by Certbot
-    listen 443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/archive.subspace.network/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/archive.subspace.network/privkey.pem; # managed by Certbot
-    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-}
-
-server {
-    if ($host = archive.subspace.network) {
-        return 301 https://$host$request_uri;
-    } # managed by Certbot
-
-
-    listen 80;
-    listen [::]:80;
-
-    server_name archive.subspace.network;
-    return 404; # managed by Certbot
 }

--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -1,14 +1,18 @@
 server {
-    root /var/www/arhive.subspace.network/html;
+    root /var/www/html;
     index index.html index.htm index.nginx-debian.html;
 
     server_name archive.subspace.network;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ @backend;
     }
 
-    location /graphql {
+    location @backend {
+        proxy_pass http://127.0.0.1:4444;
+    }
+
+    location /api {
         proxy_buffering off;
         proxy_pass http://127.0.0.1:8888/graphql;
         proxy_set_header X-Real-IP $remote_addr;
@@ -17,6 +21,19 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+        include /etc/nginx/cors-settings.conf;
+    }
+
+    location /graphql {
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:4444/graphql;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        include /etc/nginx/cors-settings.conf;
     }
 
     listen [::]:443 ssl ipv6only=on; # managed by Certbot
@@ -25,7 +42,6 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/archive.subspace.network/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-
 }
 
 server {

--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -4,7 +4,7 @@ server {
 
     server_name archive.subspace.network;
 
-    location / {
+    location ~* \.(?:css|js|json)$ { 
         try_files $uri $uri/ @backend;
     }
 

--- a/_docs/7_SubsquidArchive/cors-settings.conf
+++ b/_docs/7_SubsquidArchive/cors-settings.conf
@@ -1,0 +1,33 @@
+if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin' '*';
+
+    add_header 'Content-Security-Policy' 'upgrade-insecure-requests';
+
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+
+    add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+
+    add_header 'Access-Control-Max-Age' 1728000;
+    add_header 'Content-Type' 'text/plain charset=UTF-8';
+    add_header 'Content-Length' 0;
+    return 204;
+}
+if ($request_method = 'POST') {
+
+    add_header 'Content-Security-Policy' 'upgrade-insecure-requests';
+
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+}
+if ($request_method = 'GET') {
+
+    add_header 'Content-Security-Policy' 'upgrade-insecure-requests';
+
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+}


### PR DESCRIPTION
- Adding GraphQL explorer to Nginx setup (now available at `https://archive.subspace.network/graphql`) 
- Moving Archive to `https://archive.subspace.network/api`
- Remove Certbot generated lines from the original Nginx config