### PR TITLE
Add `BATCH_SIZE` env variable for block explorer squid

### DIFF
--- a/_docs/8_BlockExplorerSquid/docker-compose.yml
+++ b/_docs/8_BlockExplorerSquid/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       DB_NAME:
       # provide DB password
       DB_PASS:
+      BATCH_SIZE: 20
     depends_on:
       - db
       - run-migrations


### PR DESCRIPTION
Related to changes introduced in [this](https://github.com/subspace/blockexplorer/pull/37) PR