### PR TITLE
Minor update Postgres config

### DIFF
--- a/_docs/8_BlockExplorerSquid/postgresql.conf
+++ b/_docs/8_BlockExplorerSquid/postgresql.conf
@@ -23,3 +23,4 @@ max_parallel_workers = 16
 max_parallel_maintenance_workers = 4
 shared_preload_libraries='pg_stat_statements'
 pg_stat_statements.track=all
+listen_addresses = '*'

--- a/_docs/8_BlockExplorerSquid/postgresql.conf
+++ b/_docs/8_BlockExplorerSquid/postgresql.conf
@@ -24,4 +24,4 @@ max_parallel_maintenance_workers = 4
 shared_preload_libraries='pg_stat_statements'
 pg_stat_statements.track=all
 # Replace with particular IP addresses in production
-listen_addresses = '*'
+listen_addresses = 'REPLACE_IP_ADDRESS'

--- a/_docs/8_BlockExplorerSquid/postgresql.conf
+++ b/_docs/8_BlockExplorerSquid/postgresql.conf
@@ -23,4 +23,5 @@ max_parallel_workers = 16
 max_parallel_maintenance_workers = 4
 shared_preload_libraries='pg_stat_statements'
 pg_stat_statements.track=all
+# Replace with particular IP addresses in production
 listen_addresses = '*'


### PR DESCRIPTION
Add `listen_addresses` into the Postgres config (required for PgHero to connect). The actual Postgres config in the prod currently uses a particular IP address instead of `'*'`