### PR TITLE
Add `scan-start-value` parameter for `gateway` service

### DIFF
--- a/_docs/7_SubsquidArchive/docker-compose.yml
+++ b/_docs/7_SubsquidArchive/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     command: [
        "--database-url", "postgres://postgres:postgres@db:5432/squid-archive",
        "--database-max-connections", "3", # max number of concurrent database connections
+       "--scan-start-value", "20", # works as batch size but for a whole archive, default is 100
     ]
     ports:
       - "8888:8000"


### PR DESCRIPTION
Currently processing blocks gets stuck when using the default value (100) on both Gemini-2a and Gemini-3b