### PR TITLE
Update `docker-compose.yml` for Subsquid Archive

### DIFF
--- a/_docs/7_SubsquidArchive/docker-compose.yml
+++ b/_docs/7_SubsquidArchive/docker-compose.yml
@@ -33,7 +33,9 @@ services:
     command: [
        "--database-url", "postgres://postgres:postgres@db:5432/squid-archive",
        "--database-max-connections", "3", # max number of concurrent database connections
+       # these parameters have to be adjusted depending on machine resources to avoid OOM
        "--scan-start-value", "20", # works as batch size but for a whole archive, default is 100
+       "--scan-max-value", "20000" # upper limit for the amount of blocks, default is 100000
     ]
     ports:
       - "8888:8000"


### PR DESCRIPTION
Related to the recent OOM issue on Gemini-3c Archive.

Add some additional comments and the `--scan-max-value` parameter for a `gateway` service
