### PR TITLE
fix broken prune command.

### DIFF
--- a/network-primitives/bootstrap_node_provisioner.tf
+++ b/network-primitives/bootstrap_node_provisioner.tf
@@ -83,11 +83,16 @@ resource "null_resource" "prune-bootstrap-nodes" {
     timeout        = "10s"
   }
 
+  provisioner "file" {
+    source      = "${var.path-to-scripts}/prune_docker_system.sh"
+    destination = "/tmp/prune_docker_system.sh"
+  }
+
   # prune network
   provisioner "remote-exec" {
     inline = [
-      "docker ps -aq | xargs docker stop",
-      "docker system prune -a -f --volumes",
+      "sudo chmod +x /tmp/prune_docker_system.sh",
+      "sudo /tmp/prune_docker_system.sh"
     ]
   }
 }

--- a/network-primitives/farmer_node_provisioner.tf
+++ b/network-primitives/farmer_node_provisioner.tf
@@ -83,11 +83,16 @@ resource "null_resource" "prune-farmer-nodes" {
     timeout        = "10s"
   }
 
+  provisioner "file" {
+    source      = "${var.path-to-scripts}/prune_docker_system.sh"
+    destination = "/tmp/prune_docker_system.sh"
+  }
+
   # prune network
   provisioner "remote-exec" {
     inline = [
-      "docker ps -aq | xargs docker stop",
-      "docker system prune -a -f --volumes",
+      "sudo chmod +x /tmp/prune_docker_system.sh",
+      "sudo /tmp/prune_docker_system.sh"
     ]
   }
 }

--- a/network-primitives/full_node_provisioner.tf
+++ b/network-primitives/full_node_provisioner.tf
@@ -83,11 +83,16 @@ resource "null_resource" "prune-full-nodes" {
     timeout        = "10s"
   }
 
+  provisioner "file" {
+    source      = "${var.path-to-scripts}/prune_docker_system.sh"
+    destination = "/tmp/prune_docker_system.sh"
+  }
+
   # prune network
   provisioner "remote-exec" {
     inline = [
-      "docker ps -aq | xargs docker stop",
-      "docker system prune -a -f --volumes",
+      "sudo chmod +x /tmp/prune_docker_system.sh",
+      "sudo /tmp/prune_docker_system.sh"
     ]
   }
 }

--- a/network-primitives/rpc_node_provisioner.tf
+++ b/network-primitives/rpc_node_provisioner.tf
@@ -83,11 +83,16 @@ resource "null_resource" "prune-rpc-nodes" {
     timeout        = "10s"
   }
 
+  provisioner "file" {
+    source      = "${var.path-to-scripts}/prune_docker_system.sh"
+    destination = "/tmp/prune_docker_system.sh"
+  }
+
   # prune network
   provisioner "remote-exec" {
     inline = [
-      "docker ps -aq | xargs docker stop",
-      "docker system prune -a -f --volumes",
+      "sudo chmod +x /tmp/prune_docker_system.sh",
+      "sudo /tmp/prune_docker_system.sh"
     ]
   }
 }

--- a/network-primitives/scripts/prune_docker_system.sh
+++ b/network-primitives/scripts/prune_docker_system.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 systemctl stop subspace.service
+# disable the service
+systemctl disable subspace.service
+# delete the service file
+rm  /etc/systemd/system/subspace.service
 # update docker restart policy to no so that containers wont start.
 docker ps -aq | xargs docker update --restart=no
 # stop all the containers

--- a/network-primitives/scripts/prune_docker_system.sh
+++ b/network-primitives/scripts/prune_docker_system.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+systemctl stop subspace.service
+# update docker restart policy to no so that containers wont start.
+docker ps -aq | xargs docker update --restart=no
+# stop all the containers
+docker ps -aq | xargs docker stop
+# prune everything docker related
+docker system prune -a -f --volumes
+# seems like system prune is broken with docker 23.
+# so we need to prune volumes manually. Remove the following when issue is fixed.
+# TODO: https://github.com/docker/cli/issues/4028
+docker volume prune -f --filter all=1


### PR DESCRIPTION
Seems like system prune will not delete any named volumes after the recent update due to change in default. More on this here - https://github.com/docker/cli/issues/4028. For now, use the docker volume prune instead