### PR TITLE
Add health related routes to Nginx

### DIFF
--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -19,8 +19,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
         include /etc/nginx/cors-settings.conf;
     }
 
@@ -31,8 +29,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
         include /etc/nginx/cors-settings.conf;
     }
 
@@ -43,8 +39,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
         include /etc/nginx/cors-settings.conf;
     }
 
@@ -55,8 +49,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
         include /etc/nginx/cors-settings.conf;
     }
 }

--- a/_docs/7_SubsquidArchive/archive.subspace.network
+++ b/_docs/7_SubsquidArchive/archive.subspace.network
@@ -35,4 +35,28 @@ server {
         proxy_set_header Connection "upgrade";
         include /etc/nginx/cors-settings.conf;
     }
+
+    location /db-health {
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:8080/health;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        include /etc/nginx/cors-settings.conf;
+    }
+
+    location /ingest-health {
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:7070/health;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        include /etc/nginx/cors-settings.conf;
+    }
 }

--- a/_docs/8_BlockExplorerSquid/blockexplorer.subspace.network
+++ b/_docs/8_BlockExplorerSquid/blockexplorer.subspace.network
@@ -19,8 +19,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 
     location /db-health {
@@ -30,8 +28,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 
     location /processor-health {
@@ -41,7 +37,5 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 }

--- a/_docs/8_BlockExplorerSquid/blockexplorer.subspace.network
+++ b/_docs/8_BlockExplorerSquid/blockexplorer.subspace.network
@@ -22,4 +22,26 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }
+
+    location /db-health {
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:8080/health;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location /processor-health {
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:7070/health;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
 }


### PR DESCRIPTION
Add new routes to Nginx configs for Squid and Archive: `/db-health`, `/ingest-health` and `processor-health`