### PR TITLE
Vault Infra

### DIFF
--- a/explorer/.gitignore
+++ b/explorer/.gitignore
@@ -1,0 +1,6 @@
+.terraform*
+*.tfstate*
+*.tfplan
+.DS_Store
+backend_config.hcl
+*.tfvars

--- a/explorer/.gitignore
+++ b/explorer/.gitignore
@@ -1,6 +1,0 @@
-.terraform*
-*.tfstate*
-*.tfplan
-.DS_Store
-backend_config.hcl
-*.tfvars

--- a/vault/terraform/ami.tf
+++ b/vault/terraform/ami.tf
@@ -1,4 +1,4 @@
-data "aws_ami" "ubuntu_x86" {
+data "aws_ami" "ubuntu_amd64" {
   most_recent = true
 
   filter {
@@ -16,5 +16,5 @@ data "aws_ami" "ubuntu_x86" {
     values = ["x86_64"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["${var.owner}"]
 }

--- a/vault/terraform/ami.tf
+++ b/vault/terraform/ami.tf
@@ -1,0 +1,20 @@
+data "aws_ami" "ubuntu_x86" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}

--- a/vault/terraform/backend.tf
+++ b/vault/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "subspace-sre"
+
+    workspaces {
+      name = "vault-manager"
+    }
+  }
+}

--- a/vault/terraform/main.tf
+++ b/vault/terraform/main.tf
@@ -139,7 +139,7 @@ data "local_file" "private_key" {
 }
 
 resource "aws_instance" "vault" {
-  ami                         = data.aws_ami.ubuntu_x86.id # Update with the desired Vault AMI ID
+  ami                         = data.aws_ami.ubuntu_amd64.id # Update with the desired Vault AMI ID
   instance_type               = var.vault_instance_type    # Update with the desired instance type
   key_name                    = var.ssh_key_name           # Update with your SSH key pair
   subnet_id                   = aws_subnet.vault_subnet.id
@@ -156,41 +156,41 @@ resource "aws_instance" "vault" {
   }
 
   provisioner "remote-exec" {
-  inline = [
-    "export DEBIAN_FRONTEND=noninteractive",
-    "sudo apt update -y",
-    "sudo apt upgrade -y",
-    "sudo apt install git curl wget gnupg openssl make build-essential jq net-tools unzip nginx certbot python3-certbot-nginx -y",
-    "sudo bash -c 'cat <<EOF > /etc/nginx/conf.d/vault.conf",
-    "server {",
-    "  listen 80;",
-    "  server_name vault.subspace.network;",
-    "  location / {",
-    "    proxy_pass http://127.0.0.1:8200;",
-    "    proxy_set_header Host $host;",
-    "    proxy_set_header X-Real-IP $remote_addr;",
-    "    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;",
-    "    proxy_set_header X-Forwarded-Proto $scheme;",
-    "  }",
-    "}",
-    "EOF'",
-    "sudo systemctl restart nginx",
-    "echo 'export VAULT_ADDR=http://localhost:8200' | sudo tee -a /etc/environment",
-    "echo 'export VAULT_SKIP_VERIFY=true' | sudo tee -a /etc/environment",
-    "echo 'export vault_storage=s3' | sudo tee -a /etc/environment",
-    "echo 'export VAULT_BUCKET=${aws_s3_bucket.vault_storage.bucket}' | sudo tee -a /etc/environment",
-    "echo 'export VAULT_BUCKET_REGION=${var.aws_region}' | sudo tee -a /etc/environment",
-    "echo 'export AWS_ACCESS_KEY_ID=${aws_iam_access_key.vault.id}' | sudo tee -a /etc/environment",
-    "echo 'export AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.vault.secret}' | sudo tee -a /etc/environment",
-    "echo 'export VAULT_KMS_KEY_ID=${aws_kms_alias.vault.target_key_id}' | sudo tee -a /etc/environment",
-    "echo 'export VAULT_TLS_DISABLE=true' | sudo tee -a /etc/environment",
-    "curl -LO https://releases.hashicorp.com/vault/${var.vault_version}/vault_${var.vault_version}_linux_amd64.zip",
-    "unzip vault_${var.vault_version}_linux_amd64.zip",
-    "sudo mv vault /usr/local/bin/",
-    "sudo chmod +x /usr/local/bin/vault",
-    "sudo nohup vault server -config=/etc/vault-config/vault.hcl &",
-    "echo 'Installation complete'"
-  ]
+    inline = [
+      "export DEBIAN_FRONTEND=noninteractive",
+      "sudo apt update -y",
+      "sudo apt upgrade -y",
+      "sudo apt install curl gnupg openssl net-tools unzip nginx certbot python3-certbot-nginx -y",
+      "sudo bash -c 'cat <<EOF > /etc/nginx/conf.d/vault.conf",
+      "server {",
+      "  listen 80;",
+      "  server_name vault.subspace.network;",
+      "  location / {",
+      "    proxy_pass http://127.0.0.1:8200;",
+      "    proxy_set_header Host $host;",
+      "    proxy_set_header X-Real-IP $remote_addr;",
+      "    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;",
+      "    proxy_set_header X-Forwarded-Proto $scheme;",
+      "  }",
+      "}",
+      "EOF'",
+      "sudo systemctl restart nginx",
+      "echo 'export VAULT_ADDR=http://localhost:8200' | sudo tee -a /etc/environment",
+      "echo 'export VAULT_SKIP_VERIFY=true' | sudo tee -a /etc/environment",
+      "echo 'export vault_storage=s3' | sudo tee -a /etc/environment",
+      "echo 'export VAULT_BUCKET=${aws_s3_bucket.vault_storage.bucket}' | sudo tee -a /etc/environment",
+      "echo 'export VAULT_BUCKET_REGION=${var.aws_region}' | sudo tee -a /etc/environment",
+      "echo 'export AWS_ACCESS_KEY_ID=${aws_iam_access_key.vault.id}' | sudo tee -a /etc/environment",
+      "echo 'export AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.vault.secret}' | sudo tee -a /etc/environment",
+      "echo 'export VAULT_KMS_KEY_ID=${aws_kms_alias.vault.target_key_id}' | sudo tee -a /etc/environment",
+      "echo 'export VAULT_TLS_DISABLE=true' | sudo tee -a /etc/environment",
+      "curl -LO https://releases.hashicorp.com/vault/${var.vault_version}/vault_${var.vault_version}_linux_amd64.zip",
+      "unzip vault_${var.vault_version}_linux_amd64.zip",
+      "sudo mv vault /usr/local/bin/",
+      "sudo chmod +x /usr/local/bin/vault",
+      "sudo nohup vault server -config=/etc/vault-config/vault.hcl &",
+      "echo 'Installation complete'"
+    ]
 
     on_failure = continue
 

--- a/vault/terraform/main.tf
+++ b/vault/terraform/main.tf
@@ -1,0 +1,176 @@
+resource "aws_s3_bucket" "vault_storage" {
+  bucket = "vault-subspace-network"
+  force_destroy = true
+#  acl = "private"
+  depends_on = [
+    aws_iam_user.vault,
+    aws_kms_key.vault
+  ]
+
+  # Enable MFA delete protection
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_s3_bucket_acl" "acl_vault_storage" {
+  bucket = aws_s3_bucket.vault_storage.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "versioning_vault_storage" {
+  bucket = aws_s3_bucket.vault_storage.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_user" "vault" {
+  name = "vault-admin"
+
+  tags = {
+    Name = "Vault IAM User"
+  }
+}
+
+resource "aws_iam_access_key" "vault" {
+  user = aws_iam_user.vault.name
+}
+
+resource "aws_iam_policy" "vault" {
+  name        = "vault-policy"
+  description = "Policy for Vault backend access"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.vault_storage.bucket}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.vault_storage.bucket}/*"
+    },
+    {
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "vault" {
+  user       = aws_iam_user.vault.name
+  policy_arn = aws_iam_policy.vault.arn
+  depends_on = [aws_iam_policy.vault]
+}
+
+resource "aws_kms_key" "vault" {
+  description             = "Vault encryption key"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+
+resource "aws_kms_alias" "vault" {
+  name          = "alias/vault-key"
+  target_key_id = aws_kms_key.vault.key_id
+}
+
+resource "aws_security_group_rule" "vault_http" {
+  security_group_id = aws_security_group.vault_sg.id
+  type              = "ingress"
+  from_port         = 8200
+  to_port           = 8200
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"] # Restrict the CIDR block as needed
+}
+
+resource "aws_instance" "vault" {
+  ami           = data.aws_ami.ubuntu_x86.id # Update with the desired Vault AMI ID
+  instance_type = var.vault_instance_type       # Update with the desired instance type
+  key_name      = var.ssh_key_name              # Update with your SSH key pair
+  subnet_id     = aws_subnet.vault_subnet.id
+  availability_zone = var.aws_az
+
+  # Attach the IAM role to the instance
+  iam_instance_profile = aws_iam_user.vault.arn
+
+  vpc_security_group_ids = [aws_security_group.vault_sg.id]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt-get install -y nginx unzip
+              cat <<EOF-n > /etc/nginx/conf.d/vault.conf
+              server {
+                listen 80;
+                server_name vault.subspace.network;
+                location / {
+                  proxy_pass http://127.0.0.1:8200;
+                  proxy_set_header Host \$host;
+                  proxy_set_header X-Real-IP \$remote_addr;
+                  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto \$scheme;
+                }
+              }
+              EOF-n
+              sudo systemctl restart nginx
+              echo "export VAULT_ADDR=http://localhost:8200" >> /etc/environment
+              echo "export VAULT_SKIP_VERIFY=true" >> /etc/environment
+              echo "export vault_storage=s3" >> /etc/environment
+              echo "export VAULT_BUCKET=${aws_s3_bucket.vault_storage.bucket}" >> /etc/environment
+              echo "export VAULT_BUCKET_REGION=${var.aws_region}" >> /etc/environment
+              echo "export AWS_ACCESS_KEY_ID=${aws_iam_access_key.vault.id}" >> /etc/environment
+              echo "export AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.vault.secret}" >> /etc/environment
+              echo "export VAULT_KMS_KEY_ID=${aws_kms_alias.vault.target_key_id}" >> /etc/environment
+              echo "export VAULT_TLS_DISABLE=true" >> /etc/environment
+
+              curl -LO https://releases.hashicorp.com/vault/1.13.2/vault_1.13.2_linux_amd64.zip
+              unzip vault_1.13.2_linux_amd64.zip
+              mv vault /usr/local/bin/
+              chmod +x /usr/local/bin/vault
+              # Configure Vault server
+              cat > vault-config.hcl <<EOF2
+              storage "s3" {
+                bucket      = "${aws_s3_bucket.vault_storage.bucket}"
+                region      = "${var.aws_region}"  # Replace with your desired region
+                access_key  = "${aws_iam_access_key.vault.id}"
+                secret_key  = "${aws_iam_access_key.vault.secret}"
+              }
+              listener "tcp" {
+                address     = "127.0.0.1:8200"
+                tls_disable = 1
+              }
+              EOF2
+              nohup vault server -config=/etc/vault-config/vault.hcl &
+              EOF
+
+  tags = {
+    Name = "vault-server"
+  }
+}

--- a/vault/terraform/network.tf
+++ b/vault/terraform/network.tf
@@ -1,0 +1,44 @@
+# Create a VPC
+resource "aws_vpc" "vault_vpc" {
+  cidr_block = "10.0.0.0/16"
+}
+
+# Create a subnet
+resource "aws_subnet" "vault_subnet" {
+  vpc_id            = aws_vpc.vault_vpc.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-2a"
+}
+
+# Create a security group
+resource "aws_security_group" "vault_sg" {
+  vpc_id = aws_vpc.vault_vpc.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/vault/terraform/network.tf
+++ b/vault/terraform/network.tf
@@ -10,6 +10,29 @@ resource "aws_subnet" "vault_subnet" {
   availability_zone = "us-east-2a"
 }
 
+# Create an internet gateway
+resource "aws_internet_gateway" "vault_igw" {
+  vpc_id = aws_vpc.vault_vpc.id
+}
+
+# Create a route table
+resource "aws_route_table" "vault_rt" {
+  vpc_id = aws_vpc.vault_vpc.id
+}
+
+# Associate the subnet with the route table
+resource "aws_route_table_association" "vault_subnet_association" {
+  subnet_id      = aws_subnet.vault_subnet.id
+  route_table_id = aws_route_table.vault_rt.id
+}
+
+# Create a default route to the internet gateway
+resource "aws_route" "vault_internet_gateway_route" {
+  route_table_id            = aws_route_table.vault_rt.id
+  destination_cidr_block    = "0.0.0.0/0"
+  gateway_id                = aws_internet_gateway.vault_igw.id
+}
+
 # Create a security group
 resource "aws_security_group" "vault_sg" {
   vpc_id = aws_vpc.vault_vpc.id

--- a/vault/terraform/network.tf
+++ b/vault/terraform/network.tf
@@ -28,9 +28,9 @@ resource "aws_route_table_association" "vault_subnet_association" {
 
 # Create a default route to the internet gateway
 resource "aws_route" "vault_internet_gateway_route" {
-  route_table_id            = aws_route_table.vault_rt.id
-  destination_cidr_block    = "0.0.0.0/0"
-  gateway_id                = aws_internet_gateway.vault_igw.id
+  route_table_id         = aws_route_table.vault_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.vault_igw.id
 }
 
 # Create a security group

--- a/vault/terraform/outputs.tf
+++ b/vault/terraform/outputs.tf
@@ -1,0 +1,4 @@
+# Output Vault instance details
+output "vault_instance_ip" {
+  value = aws_instance.vault.public_ip
+}

--- a/vault/terraform/provider.tf
+++ b/vault/terraform/provider.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "3.15.2" # Replace with the desired version of the Vault provider
+    }
+    aws = {
+      source = "hashicorp/aws"
+      version = "4.67.0"
+    }
+  }
+}
+
+# Provider configuration (adjust as needed)
+provider "aws" {
+  region     = var.aws_region
+  access_key = var.access_key
+  secret_key = var.secret_key
+}
+
+provider "vault" {
+  address = "http://localhost:8200" # Replace with the desired Vault address
+
+  s3 {
+    bucket = aws_s3_bucket.vault_storage.id
+    region = var.aws_region # Replace with your desired AWS region
+    access_key = aws_iam_user.vault.name
+    secret_key = aws_iam_user.vault.secret
+    kms_key_id = aws_kms_key.vault.arn
+  }
+}

--- a/vault/terraform/provider.tf
+++ b/vault/terraform/provider.tf
@@ -5,7 +5,7 @@ terraform {
       version = "3.15.2" # Replace with the desired version of the Vault provider
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "4.67.0"
     }
   }
@@ -22,8 +22,8 @@ provider "vault" {
   address = "http://localhost:8200" # Replace with the desired Vault address
 
   s3 {
-    bucket = aws_s3_bucket.vault_storage.id
-    region = var.aws_region # Replace with your desired AWS region
+    bucket     = aws_s3_bucket.vault_storage.id
+    region     = var.aws_region # Replace with your desired AWS region
     access_key = aws_iam_user.vault.name
     secret_key = aws_iam_user.vault.secret
     kms_key_id = aws_kms_key.vault.arn

--- a/vault/terraform/variables.tf
+++ b/vault/terraform/variables.tf
@@ -2,6 +2,11 @@
 variable "access_key" {}
 variable "secret_key" {}
 
+variable "owner" {
+  description = "The ami image owner i.e canonical"
+  type        = string
+  default     = "099720109477"
+}
 variable "aws_region" {
   description = "The region to run the AWS resources"
   type        = string
@@ -14,8 +19,8 @@ variable "aws_az" {
   default     = "us-east-2a"
 }
 
-variable vault_version {
-  type = string
+variable "vault_version" {
+  type    = string
   default = "1.13.2"
 }
 variable "vault_admin_token" {

--- a/vault/terraform/variables.tf
+++ b/vault/terraform/variables.tf
@@ -1,0 +1,57 @@
+# Variables
+variable "access_key" {}
+variable "secret_key" {}
+
+variable "aws_region" {
+  description = "The region to run the AWS resources"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "aws_az" {
+  description = "The availability to run the AWS resources"
+  type        = string
+  default     = "us-east-2a"
+}
+
+variable "vault_admin_token" {
+  description = "The region to run the AWS resources"
+  type        = string
+  default     = ""
+}
+
+
+variable "ssh_key_name" {
+  description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+  type        = string
+  default     = "deployer"
+}
+
+variable "public_key_path" {
+  type    = string
+  default = ""
+}
+
+variable "vault_instance_type" {
+  description = "The type of EC2 Instance to run in the Vault ASG"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to deploy into. Leave an empty string to use the Default VPC in this region."
+  type        = string
+  default     = null
+}
+
+variable "s3_bucket_name" {
+  description = "The name of an S3 bucket to create and use as a storage backend (if configured). Note: S3 bucket names must be *globally* unique."
+  type        = string
+  default     = "vault_storage"
+}
+
+variable "force_destroy_s3_bucket" {
+  description = "If you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage (if configured). You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves."
+  type        = bool
+  default     = false
+}

--- a/vault/terraform/variables.tf
+++ b/vault/terraform/variables.tf
@@ -14,12 +14,15 @@ variable "aws_az" {
   default     = "us-east-2a"
 }
 
+variable vault_version {
+  type = string
+  default = "1.13.2"
+}
 variable "vault_admin_token" {
   description = "The region to run the AWS resources"
   type        = string
   default     = ""
 }
-
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
@@ -27,7 +30,7 @@ variable "ssh_key_name" {
   default     = "deployer"
 }
 
-variable "public_key_path" {
+variable "private_key_path" {
   type    = string
   default = ""
 }


### PR DESCRIPTION
This PR creates a hashicorp vault single cluster instance on AWS using terraform.
 - Backend storage S3 (encrypted / private acl)
 - KMS key to manage vault seal
 - IAM user to launch the ec2 instance with S3 access enabled.

This is required for the infrastructure to automate the process of handling keys and network deployments with CI and gitops.

Related Issue #131 