### PR TITLE
Aws cloud hsm support for cryptographic operations

### DIFF
--- a/cloud-hsm/ami.tf
+++ b/cloud-hsm/ami.tf
@@ -1,0 +1,36 @@
+data "aws_ami" "ubuntu_amd64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["099720109477"]
+}
+
+data "aws_ami" "windows_x86_64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2022-English-Full-Base-2023.07.12"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["801119661308"]
+}

--- a/cloud-hsm/backend.tf
+++ b/cloud-hsm/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "subspace-sre"
+
+    workspaces {
+      name = "cloudhsm-v2"
+    }
+  }
+}

--- a/cloud-hsm/main.tf
+++ b/cloud-hsm/main.tf
@@ -1,0 +1,50 @@
+resource "aws_instance" "windows_codesign_instance" {
+  count             = length(var.public_subnet_cidrs)
+  ami               = data.aws_ami.windows_x86_64.image_id
+  instance_type     = var.instance_type
+  subnet_id         = element(aws_subnet.cloudhsm_public_subnet.*.id, count.index)
+  availability_zone = element(var.azs, count.index)
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.cloudhsm_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+
+  tags = {
+    name       = "windows-codesign"
+    role       = "Windows HSM code signing"
+    os_name    = "windows"
+    os_version = "Microsoft Windows Server 2022 "
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.cloudhsm_public_subnet,
+    aws_nat_gateway.cloudhsm_nat_gateway,
+    aws_internet_gateway.cloudhsm_gw
+  ]
+
+  lifecycle {
+
+    create_before_destroy = true
+
+  }
+}
+
+
+resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
+  count             = length(var.private_subnet_cidrs)
+  hsm_type   = var.hsm_type
+  subnet_ids  = aws_subnet.cloudhsm_private_subnet.*.id
+
+  tags = {
+    Name = "aws_cloudhsm_v2_cluster"
+  }
+}
+
+resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
+  count             = length(var.private_subnet_cidrs)
+  subnet_id  = element(aws_subnet.cloudhsm_private_subnet.*.id, count.index)
+  cluster_id = element(aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_id, count.index)
+  availability_zone = element(var.azs, count.index)
+}

--- a/cloud-hsm/main.tf
+++ b/cloud-hsm/main.tf
@@ -33,9 +33,9 @@ resource "aws_instance" "windows_codesign_instance" {
 
 
 resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
-  count             = length(var.private_subnet_cidrs)
+  count      = length(var.private_subnet_cidrs)
   hsm_type   = var.hsm_type
-  subnet_ids  = aws_subnet.cloudhsm_private_subnet.*.id
+  subnet_ids = aws_subnet.cloudhsm_private_subnet.*.id
 
   tags = {
     Name = "aws_cloudhsm_v2_cluster"
@@ -43,8 +43,8 @@ resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
 }
 
 resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
-  count             = length(var.private_subnet_cidrs)
+  count      = length(var.private_subnet_cidrs)
   subnet_id  = element(aws_subnet.cloudhsm_private_subnet.*.id, count.index)
   cluster_id = element(aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_id, count.index)
-  availability_zone = element(var.azs, count.index)
+  # availability_zone = element(var.azs, count.index)
 }

--- a/cloud-hsm/network.tf
+++ b/cloud-hsm/network.tf
@@ -1,0 +1,165 @@
+resource "aws_vpc" "cloudhsm_vpc" {
+  cidr_block           = "172.31.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    name = "${var.vpc_id}"
+  }
+}
+
+resource "aws_subnet" "cloudhsm_public_subnet" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.cloudhsm_vpc.id
+  cidr_block              = element(var.public_subnet_cidrs, count.index)
+  availability_zone       = element(var.azs, count.index)
+  map_public_ip_on_launch = "true"
+
+  tags = {
+    Name = "${var.vpc_id}-public-subnet-${count.index}"
+  }
+}
+
+resource "aws_subnet" "cloudhsm_private_subnet" {
+  count                   = length(var.private_subnet_cidrs)
+  vpc_id                  = aws_vpc.cloudhsm_vpc.id
+  cidr_block              = element(var.private_subnet_cidrs, count.index)
+  availability_zone       = element(var.azs, count.index)
+  map_public_ip_on_launch = "false"
+
+  tags = {
+    Name = "${var.vpc_id}-private-subnet-${count.index}"
+  }
+}
+
+resource "aws_internet_gateway" "cloudhsm_gw" {
+  count  = length(var.public_subnet_cidrs)
+  vpc_id = aws_vpc.cloudhsm_vpc.id
+
+  tags = {
+    Name = "${var.vpc_id}-igw-public-subnet-${count.index}"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_route_table" "cloudhsm_public_route_table" {
+  count  = length(var.public_subnet_cidrs)
+  vpc_id = aws_vpc.cloudhsm_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.cloudhsm_gw[count.index].id
+  }
+
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.cloudhsm_gw[count.index].id
+  }
+
+  tags = {
+    Name = "${var.vpc_id}-public-route-tbl-${count.index}"
+  }
+
+  depends_on = [
+    aws_internet_gateway.cloudhsm_gw
+  ]
+}
+
+resource "aws_route_table_association" "cloudhsm_public_route_table_subnets_association" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = element(aws_subnet.cloudhsm_public_subnet.*.id, count.index)
+  route_table_id = element(aws_route_table.cloudhsm_public_route_table.*.id, count.index)
+}
+
+
+resource "aws_route_table" "cloudhsm_private_route_table" {
+  count  = length(var.private_subnet_cidrs)
+  vpc_id = aws_vpc.cloudhsm_vpc.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.cloudhsm_nat_gateway[count.index].id
+  }
+
+  tags = {
+    Name = "${var.vpc_id}-private-route-tbl-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "cloudhsm_private_route_table_subnets_association" {
+  count          = length(var.private_subnet_cidrs)
+  subnet_id      = element(aws_subnet.cloudhsm_private_subnet.*.id, count.index)
+  route_table_id = element(aws_route_table.cloudhsm_private_route_table.*.id, count.index)
+}
+
+
+resource "aws_security_group" "cloudhsm_sg" {
+  name        = "cloudhsm_sg"
+  description = "Allow HTTP and HTTPS inbound traffic"
+  vpc_id      = aws_vpc.cloudhsm_vpc.id
+
+  ingress {
+    description = "SSH for VPC"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "RDP for VPC"
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Cloud HSM client Daemon"
+    from_port   = 2223
+    to_port     = 2225
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "egress for VPC"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.vpc_id}-sg"
+  }
+
+  depends_on = [
+    aws_vpc.cloudhsm_vpc
+  ]
+}
+
+## Allocate EIP to NAT Gateway
+
+resource "aws_eip" "cloudhsm_public_subnet_eip" {
+  count = length(var.public_subnet_cidrs)
+  vpc   = true
+
+  depends_on = [
+    aws_internet_gateway.cloudhsm_gw,
+  ]
+}
+
+# NAT Gateway for public subnet
+resource "aws_nat_gateway" "cloudhsm_nat_gateway" {
+  count         = length(var.public_subnet_cidrs)
+  allocation_id = element(aws_eip.cloudhsm_public_subnet_eip.*.allocation_id, count.index)
+  subnet_id     = element(aws_subnet.cloudhsm_public_subnet.*.id, count.index)
+
+  tags = {
+    Name = "${var.vpc_id}-public-subnet-nat-GTW-${count.index}"
+  }
+}

--- a/cloud-hsm/outputs.tf
+++ b/cloud-hsm/outputs.tf
@@ -1,0 +1,80 @@
+output "vpc_id" {
+  description = "The id of the VPC that the CloudHSM cluster resides in."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.vpc_id
+}
+
+output "cluster_id" {
+  description = "The id of the CloudHSM cluster."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.id
+}
+
+output "cluster_state" {
+  description = "The state of the CloudHSM cluster."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_state
+}
+
+output "hsm_id" {
+  description = "The ID of the HSM module."
+  value       = aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.*.hsm_id
+}
+
+output "hsm_state" {
+  description = "The state of the HSM module."
+  value       = aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.*.hsm_state
+}
+
+output "hsm_eni_id" {
+  description = "The id of the ENI interface allocated for HSM module."
+  value       = aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.*.hsm_eni_id
+}
+
+output "security_group_id" {
+  description = "The ID of the security group associated with the CloudHSM cluster."
+  value       = aws_security_group.cloudhsm_sg.id
+}
+
+output "cluster_certificates" {
+  description = "The list of cluster certificates."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_certificates
+}
+
+output "cluster_certificate" {
+  description = "The cluster certificate issued by the cluster's owner's issuing CA."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_certificates.0.cluster_certificate
+}
+
+output "cluster_csr" {
+  description = "The certificate signing request (CSR)."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_certificates.0.cluster_csr
+}
+
+output "aws_hardware_certificate" {
+  description = "The HSM hardware certificate issued by AWS CloudHSM."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_certificates.0.aws_hardware_certificate
+}
+
+output "hsm_certificate" {
+  description = "The HSM certificate issued by the HSM hardware."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_certificates.0.hsm_certificate
+}
+
+output "manufacturer_hardware_certificate" {
+  description = "The HSM hardware certificate issued by the hardware manufacturer."
+  value       = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.*.cluster_certificates.0.manufacturer_hardware_certificate
+}
+
+output "windows_codesign_instance_id" {
+  value = aws_instance.windows_codesign_instance.*.id
+}
+
+output "windows_codesign_instance_private_ip" {
+  value = aws_instance.windows_codesign_instance.*.private_ip
+}
+
+output "windows_codesign_instance_public_ip" {
+  value = aws_instance.windows_codesign_instance.*.public_ip
+}
+
+output "windows_codesign_instance_ami" {
+  value = aws_instance.windows_codesign_instance.*.ami
+}

--- a/cloud-hsm/provider.tf
+++ b/cloud-hsm/provider.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.55.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">=4.7.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region[0]
+  default_tags {
+    tags = {
+      Owner   = "subspace"
+      Project = "Subspace Cloud HSM"
+    }
+  }
+}

--- a/cloud-hsm/variables.tf
+++ b/cloud-hsm/variables.tf
@@ -1,0 +1,73 @@
+
+variable "instance_type" {
+  default = "t2.micro"
+  type    = string
+}
+
+variable "hsm_type" {
+  default = "hsm1.medium"
+  type    = string
+}
+
+variable "vpc_id" {
+  default = "cloud-hsm"
+  type    = string
+}
+
+variable "instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "aws_region" {
+  description = "aws region"
+  type        = list(string)
+  default     = ["us-west-2"]
+}
+
+variable "azs" {
+  type        = list(string)
+  description = "Availability Zones"
+  default     = ["us-west-2a"]
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public Subnet CIDR values"
+  default     = ["172.31.1.0/26"]
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Private Subnet CIDR values"
+  default     = ["172.31.2.0/26"]
+}
+
+variable "disk_volume_type" {
+  type    = string
+  default = "gp3"
+}
+
+variable "aws_key_name" {
+  default = "windows-deployer"
+  type    = string
+}
+
+variable "ssh_user" {
+  type = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/windows-deployer.pem"
+}
+
+variable "secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "access_key" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
This PR creates a Cloudhsm cluster and hsm module for cryptographic key signing and storage or cryptographic keys and certificates.

Components:
- CloudHSM cluster
- CloudHSM dedicated module
- Windows EC2 instance cloudhsm client for interacting with hsm module

Other resources outside the vpc such as github runners can connect to the cloudhsm cluster via VPC peering through the Internet gateway of public subnet, which then forwards to NAT gateway to private subnet. For security and compliance reasons, we opted not to add github runners to the same VPC.