### PR TITLE
add loki logging driver and new relic

### DIFF
--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -13,18 +13,21 @@ volumes:
   archival_node_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "bootstrap-node-${NODE_ID}"
+    restart: unless-stopped
 
   dsn-bootstrap-node:
     image: ghcr.io/\${NODE_ORG}/bootstrap-node:\${NODE_TAG}
@@ -33,6 +36,10 @@ services:
       - RUST_LOG=info
     ports:
       - "30533:30533"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
       - \${DSN_NODE_KEY}
@@ -69,6 +76,10 @@ cat >> ~/subspace/docker-compose.yml << EOF
     ports:
       - "30333:30333"
       - "30433:30433"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
@@ -10,18 +10,21 @@ volumes:
   farmer_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "farmer-node-${NODE_ID}"
+    restart: unless-stopped
 
   farmer:
     depends_on:
@@ -33,6 +36,10 @@ services:
     restart: unless-stopped
     ports:
       - "30533:30533"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "farm", "path=/var/subspace,size=\${PLOT_SIZE}",
       "--node-rpc-url", "ws://archival-node:9944",
@@ -49,6 +56,10 @@ services:
     ports:
       - "30333:30333"
       - "30433:30433"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_full_node_compose_file.sh
@@ -9,18 +9,21 @@ volumes:
   archival_node_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "full-node-${NODE_ID}"
+    restart: unless-stopped
 
   archival-node:
     image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
@@ -30,6 +33,10 @@ services:
     ports:
       - "30333:30333"
       - "30433:30433"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
@@ -10,18 +10,21 @@ volumes:
   archival_node_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "rpc-node-${NODE_ID}"
+    restart: unless-stopped
 
   # caddy reverse proxy with automatic tls management using let encrypt
   caddy:
@@ -45,6 +48,10 @@ services:
       caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network
       caddy_0.handle_path_0: /ws
       caddy_0.handle_path_0.reverse_proxy: "{{upstreams 9944}}"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",


### PR DESCRIPTION
This PR makes changes to the docker compose manifests for network primitives:
- remove datadog 
- add new relic monitoring
- add loki driver to containers

closes #115 