### PR TITLE
grafana-loki logging stack

### DIFF
--- a/logging/conf/agent.yml
+++ b/logging/conf/agent.yml
@@ -3,7 +3,7 @@ integrations:
   - basic_auth:
       password: ${PROM_PASS}
       username: ${PROM_USER}
-    url: <your_prom_url>
+    url: ${PROM_URL}
   agent:
     enabled: true
     relabel_configs:
@@ -24,7 +24,7 @@ integrations:
   cadvisor:
     enabled: true
     docker_only: true
-    instance: '<your-instance-name>' # must match instance used in logs
+    instance: '${INSTANCE_NAME}' # must match instance used in logs
     relabel_configs:
     - action: replace
       replacement: integrations/docker
@@ -33,9 +33,9 @@ logs:
   configs:
   - clients:
     - basic_auth:
-        password: <your_loki_pass>
-        username: <your_loki_user>
-      url: <your_loki_url>
+        password: ${LOKI_PASS}
+        username: ${LOKI_USER}
+      url: ${LOKI_URL}
     name: integrations
     positions:
       filename: /tmp/positions.yaml
@@ -51,7 +51,7 @@ logs:
         replacement: integrations/docker
         target_label: job
       - action: replace
-        replacement: '<your-instance-name>' # must match instance used in cadvisor
+        replacement: '${INSTANCE_NAME}' # must match instance used in cadvisor
         target_label: instance
       - source_labels:
           - __meta_docker_container_name
@@ -67,7 +67,7 @@ metrics:
     - basic_auth:
         password: ${PROM_PASS}
         username: ${PROM_USER}
-      url: <your_prom_url>
+      url: ${PROM_URL}
     scrape_configs:
       # Add here any snippet that belongs to the `metrics.configs.scrape_configs` section.
       # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.

--- a/logging/conf/agent.yml
+++ b/logging/conf/agent.yml
@@ -1,0 +1,76 @@
+integrations:
+  prometheus_remote_write:
+  - basic_auth:
+      password: ${PROM_PASS}
+      username: ${PROM_USER}
+    url: <your_prom_url>
+  agent:
+    enabled: true
+    relabel_configs:
+    - action: replace
+      source_labels:
+      - agent_hostname
+      target_label: instance
+    - action: replace
+      target_label: job
+      replacement: "integrations/agent-check"
+    metric_relabel_configs:
+    - action: keep
+      regex: (prometheus_target_.*|prometheus_sd_discovered_targets|agent_build.*|agent_wal_samples_appended_total|process_start_time_seconds)
+      source_labels:
+      - __name__
+  # Add here any snippet that belongs to the `integrations` section.
+  # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+  cadvisor:
+    enabled: true
+    docker_only: true
+    instance: '<your-instance-name>' # must match instance used in logs
+    relabel_configs:
+    - action: replace
+      replacement: integrations/docker
+      target_label: job
+logs:
+  configs:
+  - clients:
+    - basic_auth:
+        password: <your_loki_pass>
+        username: <your_loki_user>
+      url: <your_loki_url>
+    name: integrations
+    positions:
+      filename: /tmp/positions.yaml
+    scrape_configs:
+      # Add here any snippet that belongs to the `logs.configs.scrape_configs` section.
+      # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+    - job_name: integrations/docker
+      docker_sd_configs:
+        - host: unix:///var/run/docker.sock
+          refresh_interval: 5s
+      relabel_configs:
+      - action: replace
+        replacement: integrations/docker
+        target_label: job
+      - action: replace
+        replacement: '<your-instance-name>' # must match instance used in cadvisor
+        target_label: instance
+      - source_labels:
+          - __meta_docker_container_name
+        regex: '/(.*)'
+        target_label: container
+      - source_labels:
+          - __meta_docker_container_log_stream
+        target_label: stream
+metrics:
+  configs:
+  - name: integrations
+    remote_write:
+    - basic_auth:
+        password: ${PROM_PASS}
+        username: ${PROM_USER}
+      url: <your_prom_url>
+    scrape_configs:
+      # Add here any snippet that belongs to the `metrics.configs.scrape_configs` section.
+      # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+  global:
+    scrape_interval: 60s
+  wal_directory: /tmp/grafana-agent-wal

--- a/logging/conf/loki-config.yml
+++ b/logging/conf/loki-config.yml
@@ -1,0 +1,67 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  wal:
+    enabled: true
+    dir: /tmp/wal
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2023-09-13
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+compactor:
+  working_directory: /loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/logging/conf/mimir.yml
+++ b/logging/conf/mimir.yml
@@ -1,0 +1,61 @@
+multitenancy_enabled: false
+
+activity_tracker: {}
+
+alertmanager: {}
+
+alertmanager_storage:
+  backend: local
+
+server:
+  http_listen_port: 9009
+
+  # Configure the server to allow messages up to 100MB.
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_max_concurrent_streams: 1000
+
+distributor:
+  pool:
+    health_check_ingesters: true
+
+ingester_client:
+  grpc_client_config:
+    grpc_compression: gzip
+    max_recv_msg_size: 104857600
+    max_send_msg_size: 104857600
+
+ingester:
+  ring:
+    final_sleep: 0s
+    kvstore:
+      store: inmemory
+    min_ready_duration: 0s
+    num_tokens: 512
+    replication_factor: 1
+
+blocks_storage:
+  backend: filesystem
+  bucket_store:
+    sync_dir: /tmp/mimir/tsdb-sync
+  filesystem:
+    dir: /tmp/mimir/blocks
+  tsdb:
+    dir: /tmp/mimir/tsdb
+
+compactor:
+  sharding_ring:
+    kvstore:
+      store: inmemory
+
+ruler:
+  enable_api: true
+
+ruler_storage:
+  backend: filesystem
+  local:
+    directory: /tmp/mimir/rules
+
+limits:
+  ingestion_burst_size: 500000
+  ingestion_rate: 250000

--- a/logging/grafana-loki/docker-compose.yml
+++ b/logging/grafana-loki/docker-compose.yml
@@ -35,18 +35,20 @@ services:
   mimir:
     image: grafana/mimir:2.9.0
     volumes:
-      - /root/mimir/conf:/etc/mimir-config:ro
+      - /root/mimir/conf/etc/mimir.yml:/etc/mimir-config/mimir.yml:ro
     entrypoint:
       - /bin/mimir
       - -config.file=/etc/mimir-config/mimir.yml
     ports:
       - "9009:9009"
+    networks:
+      - loki
 
   agent:
     profiles: [agent]
     image: grafana/agent:latest
     volumes:
-      - /root/agent/conf:/etc/agent-config:ro
+      - /root/agent/conf/etc/agent.yml:/etc/agent-config/agent.yml:ro
     entrypoint:
       - /bin/grafana-agent
       - -server.http.address=0.0.0.0:12345
@@ -61,6 +63,8 @@ services:
       LOKI_HOST: loki:3100
     ports:
       - "12345:12345"
+    networks:
+      - loki
     depends_on:
       - mimir
       - loki

--- a/logging/grafana-loki/docker-compose.yml
+++ b/logging/grafana-loki/docker-compose.yml
@@ -32,6 +32,39 @@ services:
     networks:
       - loki
 
+  mimir:
+    image: grafana/mimir:2.9.0
+    volumes:
+      - /root/mimir/conf:/etc/mimir-config:ro
+    entrypoint:
+      - /bin/mimir
+      - -config.file=/etc/mimir-config/mimir.yml
+    ports:
+      - "9009:9009"
+
+  agent:
+    profiles: [agent]
+    image: grafana/agent:latest
+    volumes:
+      - /root/agent/conf:/etc/agent-config:ro
+    entrypoint:
+      - /bin/grafana-agent
+      - -server.http.address=0.0.0.0:12345
+      - -config.file=/etc/agent-config/agent.yml
+      - -metrics.wal-directory=/tmp/agent/wal
+      - -enable-features=integrations-next
+      - -config.expand-env
+      - -config.enable-read-api
+    environment:
+      HOSTNAME: agent
+      REMOTE_WRITE_HOST: mimir:9009
+      LOKI_HOST: loki:3100
+    ports:
+      - "12345:12345"
+    depends_on:
+      - mimir
+      - loki
+
   grafana:
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning

--- a/logging/grafana-loki/docker-compose.yml
+++ b/logging/grafana-loki/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "3.7"
+
+networks:
+  traefik-proxy:
+    external: true
+  loki:
+
+services:
+  loki:
+    image: grafana/loki:2.9.0
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/loki-config.yaml
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.loki.loadbalancer.server.port=3100
+      - traefik.http.routers.loki.rule=Host(`logging.subspace.network`)
+      - traefik.http.routers.loki.tls.certresolver=le
+      - traefik.http.routers.loki.entrypoints=websecure
+      - traefik.docker.network=traefik-proxy
+    volumes:
+      - /root/loki/conf/loki/etc/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+    networks:
+      - loki
+      - traefik-proxy
+
+  promtail:
+    image: grafana/promtail:2.9.0
+    command: -config.file=/etc/promtail/config.yml
+    ports:
+      - 127.0.0.1:3200:3100
+    networks:
+      - loki
+
+  grafana:
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana-data:/var/lib/grafana
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+      - traefik.http.routers.grafana.rule=Host(`grafana.subspace.network`)
+      - traefik.http.routers.grafana.tls.certresolver=le
+      - traefik.http.routers.grafana.entrypoints=websecure
+      - traefik.docker.network=traefik-proxy
+    networks:
+      - loki
+      - traefik-proxy
+
+volumes:
+  grafana-data:
+  loki-data:

--- a/logging/host/docker-compose.yml
+++ b/logging/host/docker-compose.yml
@@ -1,0 +1,84 @@
+version: "3.7"
+
+volumes:
+  prometheus_data: {}
+
+networks:
+  back-tier:
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.36.2
+    volumes:
+      - ./etc/prometheus/conf:/etc/prometheus/
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    ports:
+      - 9090:9090
+    links:
+      - cadvisor:cadvisor
+    depends_on:
+      - cadvisor
+    networks:
+      - back-tier
+    restart: always
+
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:latest
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+      - /:/host:ro,rslave
+    command:
+      - "--path.rootfs=/host"
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - --collector.filesystem.ignored-mount-points
+      - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
+    ports:
+      - 9100:9100
+    networks:
+      - back-tier
+    restart: always
+    deploy:
+      mode: global
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    ports:
+      - 8080:8080
+    networks:
+      - back-tier
+    restart: always
+    deploy:
+      mode: global
+
+  agent:
+    profiles: [agent]
+    image: grafana/agent:latest
+    volumes:
+      - ./etc/agent/conf:/etc/agent-config:ro
+    entrypoint:
+      - /bin/grafana-agent
+      - -server.http.address=0.0.0.0:12345
+      - -config.file=/etc/agent-config/agent.yml
+      - -metrics.wal-directory=/tmp/agent/wal
+      - -enable-features=integrations-next
+      - -config.expand-env
+      - -config.enable-read-api
+    environment:
+      HOSTNAME: agent
+      REMOTE_WRITE_HOST: mimir:9009
+      LOKI_HOST: loki:3100
+    ports:
+      - "12345:12345"
+    networks:
+      - back-tier

--- a/logging/host/docker-compose.yml
+++ b/logging/host/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   prometheus:
     image: prom/prometheus:v2.36.2
     volumes:
-      - ./etc/prometheus/conf:/etc/prometheus/
+      - ./etc/prometheus/conf/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -65,7 +65,7 @@ services:
     profiles: [agent]
     image: grafana/agent:latest
     volumes:
-      - ./etc/agent/conf:/etc/agent-config:ro
+      - ./etc/agent/conf/agent.yml:/etc/agent-config/agent.yml:ro
     entrypoint:
       - /bin/grafana-agent
       - -server.http.address=0.0.0.0:12345

--- a/logging/host/etc/agent.yml
+++ b/logging/host/etc/agent.yml
@@ -19,12 +19,11 @@ integrations:
       regex: (prometheus_target_.*|prometheus_sd_discovered_targets|agent_build.*|agent_wal_samples_appended_total|process_start_time_seconds)
       source_labels:
       - __name__
-  # Add here any snippet that belongs to the `integrations` section.
-  # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+
   cadvisor:
     enabled: true
     docker_only: true
-    instance: ${HOST_NAME} # must match instance used in logs
+    instance: ${INSTANCE_NAME} # must match instance used in logs
     relabel_configs:
     - action: replace
       replacement: integrations/docker
@@ -41,7 +40,6 @@ logs:
       filename: /tmp/positions.yaml
     scrape_configs:
       # Add here any snippet that belongs to the `logs.configs.scrape_configs` section.
-      # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
     - job_name: integrations/docker
       docker_sd_configs:
         - host: unix:///var/run/docker.sock
@@ -67,7 +65,7 @@ metrics:
     - basic_auth:
         password: ${PROM_PASS}
         username: ${PROM_USER}
-      url: <your_prom_url>
+      url: ${PROM_URL}
     scrape_configs:
       # Add here any snippet that belongs to the `metrics.configs.scrape_configs` section.
       # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.

--- a/logging/host/etc/agent.yml
+++ b/logging/host/etc/agent.yml
@@ -1,0 +1,76 @@
+integrations:
+  prometheus_remote_write:
+  - basic_auth:
+      password: ${PROM_PASS}
+      username: ${PROM_USER}
+    url: ${PROM_URL}
+  agent:
+    enabled: true
+    relabel_configs:
+    - action: replace
+      source_labels:
+      - agent_hostname
+      target_label: instance
+    - action: replace
+      target_label: job
+      replacement: "integrations/agent-check"
+    metric_relabel_configs:
+    - action: keep
+      regex: (prometheus_target_.*|prometheus_sd_discovered_targets|agent_build.*|agent_wal_samples_appended_total|process_start_time_seconds)
+      source_labels:
+      - __name__
+  # Add here any snippet that belongs to the `integrations` section.
+  # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+  cadvisor:
+    enabled: true
+    docker_only: true
+    instance: ${HOST_NAME} # must match instance used in logs
+    relabel_configs:
+    - action: replace
+      replacement: integrations/docker
+      target_label: job
+logs:
+  configs:
+  - clients:
+    - basic_auth:
+        password: ${LOKI_PASS}
+        username: ${LOKI_USER}
+      url: ${LOKI_URL}
+    name: integrations
+    positions:
+      filename: /tmp/positions.yaml
+    scrape_configs:
+      # Add here any snippet that belongs to the `logs.configs.scrape_configs` section.
+      # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+    - job_name: integrations/docker
+      docker_sd_configs:
+        - host: unix:///var/run/docker.sock
+          refresh_interval: 5s
+      relabel_configs:
+      - action: replace
+        replacement: integrations/docker
+        target_label: job
+      - action: replace
+        replacement: ${INSTANCE_NAME} # must match instance used in cadvisor
+        target_label: instance
+      - source_labels:
+          - __meta_docker_container_name
+        regex: '/(.*)'
+        target_label: container
+      - source_labels:
+          - __meta_docker_container_log_stream
+        target_label: stream
+metrics:
+  configs:
+  - name: integrations
+    remote_write:
+    - basic_auth:
+        password: ${PROM_PASS}
+        username: ${PROM_USER}
+      url: <your_prom_url>
+    scrape_configs:
+      # Add here any snippet that belongs to the `metrics.configs.scrape_configs` section.
+      # For a correct indentation, paste snippets copied from Grafana Cloud at the beginning of the line.
+  global:
+    scrape_interval: 60s
+  wal_directory: /tmp/grafana-agent-wal

--- a/logging/host/etc/prometheus.yml
+++ b/logging/host/etc/prometheus.yml
@@ -3,54 +3,25 @@ global:
   evaluation_interval: 15s
   # scrape_timeout is set to the global default (10s).
 
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
-  # external_labels:
-  #     monitor: 'my-project'
-
-# Load and evaluate rules in this file every 'evaluation_interval' seconds.
-rule_files:
-  - 'alert.rules'
-  # - "first.rules"
-  # - "second.rules"
-
-# alert
-# alerting:
-#   alertmanagers:
-#   - scheme: http
-#     static_configs:
-#     - targets:
-#       - "alertmanager:9093"
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
+# A scrape configuration containing endpoints to scrape:
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-
   - job_name: 'prometheus'
-
     scrape_interval: 15s
-
     static_configs:
          - targets: ['localhost:9090']
 
   - job_name: 'cadvisor'
-
     scrape_interval: 15s
-
     static_configs:
       - targets: ['cadvisor:8080']
 
   - job_name: 'node-exporter'
-
     scrape_interval: 15s
-
     static_configs:
       - targets: ['node-exporter:9100']
 
   - job_name: "subspace_node"
-
     scrape_interval: 5s
-
     static_configs:
       - targets: ["archival-node:9615"]

--- a/logging/host/etc/prometheus.yml
+++ b/logging/host/etc/prometheus.yml
@@ -1,0 +1,56 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  # external_labels:
+  #     monitor: 'my-project'
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - 'alert.rules'
+  # - "first.rules"
+  # - "second.rules"
+
+# alert
+# alerting:
+#   alertmanagers:
+#   - scheme: http
+#     static_configs:
+#     - targets:
+#       - "alertmanager:9093"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+
+  - job_name: 'prometheus'
+
+    scrape_interval: 15s
+
+    static_configs:
+         - targets: ['localhost:9090']
+
+  - job_name: 'cadvisor'
+
+    scrape_interval: 15s
+
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  - job_name: 'node-exporter'
+
+    scrape_interval: 15s
+
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: "subspace_node"
+
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ["archival-node:9615"]

--- a/logging/traefik/acme.sh
+++ b/logging/traefik/acme.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+USER=$USER
+DIRECTORY="/home/${USER}/traefik"
+if [ ! -d "$DIRECTORY" ]; then
+    mkdir "$DIRECTORY"
+    echo "Directory '$DIRECTORY' created."
+    touch $DIRECTORY/acme.json
+    chmod 600 $DIRECTORY/acme.json
+    echo "ACME '$DIRECTORY/acme.json' file created."
+else
+    echo "Directory '$DIRECTORY' already exists."
+fi

--- a/logging/traefik/acme.sh
+++ b/logging/traefik/acme.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-USER=$USER
-DIRECTORY="/home/${USER}/traefik"
+DIRECTORY="/root/traefik"
 if [ ! -d "$DIRECTORY" ]; then
     mkdir "$DIRECTORY"
     echo "Directory '$DIRECTORY' created."

--- a/logging/traefik/docker-compose.yml
+++ b/logging/traefik/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+networks:
+  default:
+    name: traefik-proxy
+
+services:
+  traefik:
+    image: traefik:latest
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      - --api=true
+      - --api.dashboard=false
+      - --providers.docker
+      - --log.level=info
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entryPoint.to=websecure
+      - --entrypoints.websecure.address=:443
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --certificatesresolvers.le.acme.email=alerts@subspace.network
+      - --certificatesresolvers.le.acme.storage=/acme.json
+      - --certificatesresolvers.le.acme.tlschallenge=true
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /root/traefik/acme.json:/acme.json


### PR DESCRIPTION
This PR creates a grafana loki stack with docker compose and traefik reverse proxy. 
- add grafana
- add loki
- serve frontend with traefik

closes #144 & #147 
