### PR TITLE
Ephemeral testing framework

### DIFF
--- a/testing-framework/ec2/base/ami.tf
+++ b/testing-framework/ec2/base/ami.tf
@@ -1,0 +1,20 @@
+data "aws_ami" "ubuntu_amd64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}

--- a/testing-framework/ec2/base/bootstrap_node_provisioner.tf
+++ b/testing-framework/ec2/base/bootstrap_node_provisioner.tf
@@ -153,7 +153,7 @@ resource "null_resource" "start-boostrap-nodes" {
       "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.bootstrap_nodes_ip_v4)} ${count.index}",
 
       # start subspace node
-      # "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
     ]
   }
 }

--- a/testing-framework/ec2/base/bootstrap_node_provisioner.tf
+++ b/testing-framework/ec2/base/bootstrap_node_provisioner.tf
@@ -1,0 +1,159 @@
+locals {
+  bootstrap_nodes_ip_v4 = flatten([
+    [aws_instance.bootstrap_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-bootstrap-nodes" {
+  count = length(local.bootstrap_nodes_ip_v4)
+
+  depends_on = [aws_instance.bootstrap_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.bootstrap_nodes_ip_v4)
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/subspace/installer.sh",
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /home/${var.ssh_user}/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-bootstrap-nodes" {
+  count      = var.bootstrap-node-config.prune ? length(local.bootstrap_nodes_ip_v4) : 0
+  depends_on = [null_resource.setup-bootstrap-nodes]
+
+  triggers = {
+    prune = var.bootstrap-node-config.prune
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/subspace/prune_docker_system.sh",
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-boostrap-nodes" {
+  count = length(local.bootstrap_nodes_ip_v4)
+
+  depends_on = [null_resource.setup-bootstrap-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.bootstrap-node-config.deployment-version
+    reserved_only      = var.bootstrap-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy bootstrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_bootstrap_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-bootstrap-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.bootstrap-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.bootstrap-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_LISTEN_PORT=${var.bootstrap-node-config.dsn-listen-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.bootstrap-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo GENESIS_HASH=${var.bootstrap-node-config.genesis-hash} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "chmod +x /home/${var.ssh_user}/subspace/create_compose_file.sh",
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.bootstrap_nodes_ip_v4)} ${count.index}",
+
+      # start subspace node
+      # "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/testing-framework/ec2/base/domain_node_provisioner.tf
+++ b/testing-framework/ec2/base/domain_node_provisioner.tf
@@ -193,6 +193,7 @@ resource "null_resource" "inject-domain-keystore" {
     timeout     = "300s"
   }
 
+  # comment if don't need to inject a seed for domain node in testing environment.
   provisioner "remote-exec" {
     inline = [
       "sudo docker cp /home/${var.ssh_user}/subspace/keystore/.  subspace-archival-node-1:/var/subspace/keystore/"

--- a/testing-framework/ec2/base/domain_node_provisioner.tf
+++ b/testing-framework/ec2/base/domain_node_provisioner.tf
@@ -1,0 +1,201 @@
+locals {
+  domain_node_ip_v4 = flatten([
+    [aws_instance.domain_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-domain-nodes" {
+  count = length(local.domain_node_ip_v4)
+
+  depends_on = [aws_instance.domain_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.domain_node_ip_v4)
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /home/${var.ssh_user}/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-domain-nodes" {
+  count      = var.domain-node-config.prune ? length(local.domain_node_ip_v4) : 0
+  depends_on = [null_resource.setup-domain-nodes]
+
+  triggers = {
+    prune = var.domain-node-config.prune
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-domain-nodes" {
+  count = length(local.domain_node_ip_v4)
+
+  depends_on = [null_resource.setup-domain-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.domain-node-config.deployment-version
+    reserved_only      = var.domain-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./domain_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy dsn_boostrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy keystore
+  provisioner "file" {
+    source      = "./keystore"
+    destination = "/home/${var.ssh_user}/subspace/keystore/"
+  }
+
+  # copy relayer ids
+  provisioner "file" {
+    source      = "./relayer_ids.txt"
+    destination = "/home/${var.ssh_user}/subspace/relayer_ids.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_domain_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-domain-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.domain-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.domain-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_PREFIX=${var.domain-node-config.domain-prefix} >> /home/${var.ssh_user}/subspace/.env",
+      # //todo use a map for domain id and labels
+      "echo DOMAIN_LABEL=${var.domain-node-config.domain-labels[0]} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_ID=${var.domain-node-config.domain-id[0]} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo RELAYER_SYSTEM_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_SYSTEM_ID=//p' /home/${var.ssh_user}/subspace/relayer_ids.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo RELAYER_DOMAIN_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_DOMAIN_ID=//p' /home/${var.ssh_user}/subspace/relayer_ids.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.domain-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.domain_node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains} ${var.domain-node-config.domain-id[0]}",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}
+
+resource "null_resource" "inject-domain-keystore" {
+  # for now we have one executor running. Should change here when multiple executors are expected.
+  count      = length(local.domain_node_ip_v4) > 0 ? 1 : 0
+  depends_on = [null_resource.start-domain-nodes]
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.domain-node-config.deployment-version
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[0]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo docker cp /home/${var.ssh_user}/subspace/keystore/.  subspace-archival-node-1:/var/subspace/keystore/"
+    ]
+  }
+}

--- a/testing-framework/ec2/base/farmer_node_provisioner.tf
+++ b/testing-framework/ec2/base/farmer_node_provisioner.tf
@@ -153,7 +153,7 @@ resource "null_resource" "start-farmer-nodes" {
       "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
 
       # start subspace
-      # "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
     ]
   }
 }

--- a/testing-framework/ec2/base/farmer_node_provisioner.tf
+++ b/testing-framework/ec2/base/farmer_node_provisioner.tf
@@ -1,0 +1,171 @@
+locals {
+  farmer_node_ipv4 = flatten([
+    [aws_instance.farmer_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-farmer-nodes" {
+  count = length(local.farmer_node_ipv4)
+
+  depends_on = [aws_instance.farmer_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.farmer_node_ipv4)
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/farmer_data/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/",
+      "sudo chown -R nobody:nogroup /home/${var.ssh_user}/subspace/farmer_data/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/subspace/installer.sh",
+      "sudo /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /home/${var.ssh_user}/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-farmer-nodes" {
+  count      = var.farmer-node-config.prune ? length(local.farmer_node_ipv4) : 0
+  depends_on = [null_resource.setup-farmer-nodes]
+
+  triggers = {
+    prune = var.farmer-node-config.prune
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/subspace/prune_docker_system.sh",
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-farmer-nodes" {
+  count = length(local.farmer_node_ipv4)
+
+  depends_on = [null_resource.setup-farmer-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.farmer-node-config.deployment-version
+    reserved_only      = var.farmer-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy farmer identity files
+  provisioner "file" {
+    source      = "./identity.bin"
+    destination = "/home/${var.ssh_user}/subspace/farmer_data/identity.bin"
+  }
+
+  provisioner "file" {
+    source      = "./single_disk_plot.json"
+    destination = "/home/${var.ssh_user}/subspace/farmer_data/single_disk_plot.json"
+  }
+
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_farmer_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-farmer-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.farmer-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.farmer-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo REWARD_ADDRESS=${var.farmer-node-config.reward-address} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PLOT_SIZE=${var.farmer-node-config.plot-size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.farmer-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "chmod +x /home/${var.ssh_user}/subspace/create_compose_file.sh",
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
+
+      # start subspace
+      # "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/testing-framework/ec2/base/farmer_node_provisioner.tf
+++ b/testing-framework/ec2/base/farmer_node_provisioner.tf
@@ -110,18 +110,6 @@ resource "null_resource" "start-farmer-nodes" {
     timeout     = "300s"
   }
 
-  # copy farmer identity files
-  provisioner "file" {
-    source      = "./identity.bin"
-    destination = "/home/${var.ssh_user}/subspace/farmer_data/identity.bin"
-  }
-
-  provisioner "file" {
-    source      = "./single_disk_plot.json"
-    destination = "/home/${var.ssh_user}/subspace/farmer_data/single_disk_plot.json"
-  }
-
-
   # copy boostrap node keys file
   provisioner "file" {
     source      = "./bootstrap_node_keys.txt"

--- a/testing-framework/ec2/base/instances.tf
+++ b/testing-framework/ec2/base/instances.tf
@@ -1,0 +1,249 @@
+resource "aws_instance" "bootstrap_node" {
+  count             = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.instance_type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.bootstrap-node-config.disk-volume-size
+    volume_type = var.bootstrap-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+
+  tags = {
+    Name       = "${var.network_name}-bootstrap-${count.index}"
+    name       = "${var.network_name}-bootstrap-${count.index}"
+    role       = "bootstrap node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+resource "aws_instance" "node" {
+  count = length(var.aws_region) * var.node-config.instance-count
+  ami   = data.aws_ami.ubuntu_amd64.image_id
+  # instance_type     = var.instance_type
+  instance_type     = var.instance_type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.node-config.disk-volume-size
+    volume_type = var.node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+  tags = {
+    Name       = "${var.network_name}-${count.index}"
+    name       = "${var.network_name}-${count.index}"
+    role       = "subspace node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+resource "aws_instance" "domain_node" {
+  count             = length(var.aws_region) * var.domain-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.instance_type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.domain-node-config.disk-volume-size
+    volume_type = var.domain-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+  tags = {
+    Name       = "${var.network_name}-domain-${count.index}"
+    name       = "${var.network_name}-domain-${count.index}"
+    role       = "domain node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+
+resource "aws_instance" "farmer_node" {
+  count             = length(var.aws_region) * var.farmer-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.instance_type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.farmer-node-config.disk-volume-size
+    volume_type = var.farmer-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+  tags = {
+    Name       = "${var.network_name}-farmer-${count.index}"
+    name       = "${var.network_name}-farmer-${count.index}"
+    role       = "farmer node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}

--- a/testing-framework/ec2/base/network.tf
+++ b/testing-framework/ec2/base/network.tf
@@ -1,0 +1,142 @@
+resource "aws_vpc" "network_vpc" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    name = "${var.network_name}-vpc"
+  }
+}
+
+resource "aws_subnet" "public_subnets" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.network_vpc.id
+  cidr_block              = element(var.public_subnet_cidrs, count.index)
+  availability_zone       = var.azs
+  map_public_ip_on_launch = "true"
+
+  tags = {
+    Name = "${var.network_name}-test-subnet-${count.index}"
+  }
+}
+
+
+resource "aws_internet_gateway" "gw" {
+  count  = length(var.public_subnet_cidrs)
+  vpc_id = aws_vpc.network_vpc.id
+
+  tags = {
+    Name = "${var.network_name}-igw-test-subnet-${count.index}"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_route_table" "public_route_table" {
+  count  = length(var.public_subnet_cidrs)
+  vpc_id = aws_vpc.network_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw[count.index].id
+  }
+
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.gw[count.index].id
+  }
+
+  tags = {
+    Name = "${var.network_name}-public-route-tbl-${count.index}"
+  }
+
+  depends_on = [
+    aws_internet_gateway.gw
+  ]
+}
+
+resource "aws_route_table_association" "public_route_table_subnets_association" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = element(aws_subnet.public_subnets.*.id, count.index)
+  route_table_id = element(aws_route_table.public_route_table.*.id, count.index)
+}
+
+resource "aws_security_group" "network_sg" {
+  name        = "${var.network_name}-network-sg"
+  description = "Allow HTTP and HTTPS inbound traffic"
+  vpc_id      = aws_vpc.network_vpc.id
+
+  ingress {
+    description = "HTTPS for VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP for VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "SSH for VPC"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Node Port 30333 for VPC"
+    from_port   = 30333
+    to_port     = 30333
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Node Port 30433 for VPC"
+    from_port   = 30433
+    to_port     = 30433
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Domain Bootstrap Node Port 40333 for VPC"
+    from_port   = 40333
+    to_port     = 40333
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Farmer Port 30533 for VPC"
+    from_port   = 30533
+    to_port     = 30533
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "egress for VPC"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.network_name}_sg"
+  }
+
+  depends_on = [
+    aws_vpc.network_vpc
+  ]
+}

--- a/testing-framework/ec2/base/node_provisioner.tf
+++ b/testing-framework/ec2/base/node_provisioner.tf
@@ -1,0 +1,161 @@
+locals {
+  node_ip_v4 = flatten([
+    [aws_instance.node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-nodes" {
+  count = length(local.node_ip_v4)
+
+  depends_on = [aws_instance.node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.node_ip_v4)
+  }
+
+  connection {
+    host        = local.node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/subspace/installer.sh",
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /home/${var.ssh_user}/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-nodes" {
+  count      = var.node-config.prune ? length(local.node_ip_v4) : 0
+  depends_on = [null_resource.setup-nodes]
+
+  triggers = {
+    prune = var.node-config.prune
+  }
+
+  connection {
+    host        = local.node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/subspace/prune_docker_system.sh",
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-nodes" {
+  count = length(local.node_ip_v4)
+
+  depends_on = [null_resource.setup-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.node-config.deployment-version
+    reserved_only      = var.node-config.reserved-only
+  }
+
+  connection {
+    host        = local.node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "chmod +x /home/${var.ssh_user}/subspace/create_compose_file.sh",
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)}",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/testing-framework/ec2/base/outputs.tf
+++ b/testing-framework/ec2/base/outputs.tf
@@ -1,0 +1,67 @@
+// Output Variables
+
+output "bootstrap_node_server_id" {
+  value = aws_instance.bootstrap_node.*.id
+}
+
+output "bootstrap_node_public_ip" {
+  value = aws_instance.bootstrap_node.*.public_ip
+}
+
+output "bootstrap_node_private_ip" {
+  value = aws_instance.bootstrap_node.*.private_ip
+}
+
+output "bootstrap_node_ami" {
+  value = aws_instance.bootstrap_node.*.ami
+}
+
+
+output "node_server_id" {
+  value = aws_instance.node.*.id
+}
+
+output "node_private_ip" {
+  value = aws_instance.node.*.private_ip
+}
+
+output "node_public_ip" {
+  value = aws_instance.node.*.public_ip
+}
+
+output "node_ami" {
+  value = aws_instance.node.*.ami
+}
+
+output "domain_node_server_id" {
+  value = aws_instance.domain_node.*.id
+}
+
+output "domain_node_private_ip" {
+  value = aws_instance.domain_node.*.private_ip
+}
+
+output "domain_node_public_ip" {
+  value = aws_instance.domain_node.*.public_ip
+}
+
+output "domain_node_ami" {
+  value = aws_instance.domain_node.*.ami
+}
+
+
+output "farmer_node_server_id" {
+  value = aws_instance.farmer_node.*.id
+}
+
+output "farmer_node_private_ip" {
+  value = aws_instance.farmer_node.*.private_ip
+}
+
+output "farmer_node_public_ip" {
+  value = aws_instance.farmer_node.*.public_ip
+}
+
+output "farmer_node_ami" {
+  value = aws_instance.farmer_node.*.ami
+}

--- a/testing-framework/ec2/base/provider.tf
+++ b/testing-framework/ec2/base/provider.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.55.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region[0]
+  default_tags {
+    tags = {
+      Environment = "${var.vpc_id}-testing"
+      Owner       = "subspace"
+      Project     = "Subspace Network"
+    }
+  }
+}
+
+provider "tfe" {
+  token = var.tf_token
+}

--- a/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+
+services:
+  dsn-bootstrap-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-bootstrap-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=info
+    ports:
+      - "30533:30533"
+    command:
+      - start
+      - \${DSN_NODE_KEY}
+      - /ip4/0.0.0.0/tcp/30533
+      - --protocol-version
+      - \${GENESIS_HASH}
+      - "--in-peers"
+      - "1000"
+      - "--out-peers"
+      - "1000"
+      - "--pending-in-peers"
+      - "1000"
+      - "--pending-out-peers"
+      - "1000"
+      - "--external-address"
+      - "/ip4/$EXTERNAL_IP/tcp/30533"
+EOF
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--reserved-peers\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"--bootstrap-nodes\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+cat >> ~/subspace/docker-compose.yml << EOF
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--in-peers-light", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+    echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  fi
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
@@ -15,8 +15,8 @@ volumes:
 services:
   dsn-bootstrap-node:
     build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-bootstrap-node
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-bootstrap-node
     image: \${NODE_ORG}/node:\${NODE_TAG}
     restart: unless-stopped
     environment:
@@ -54,7 +54,10 @@ done
 
 cat >> ~/subspace/docker-compose.yml << EOF
   archival-node:
-    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
     restart: unless-stopped

--- a/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 reserved_only=${1}
 node_count=${2}
@@ -25,7 +25,9 @@ services:
       - "30533:30533"
     command:
       - start
+      - "--keypair"
       - \${DSN_NODE_KEY}
+      - "--listen-on"
       - /ip4/0.0.0.0/tcp/30533
       - --protocol-version
       - \${GENESIS_HASH}
@@ -52,16 +54,14 @@ done
 
 cat >> ~/subspace/docker-compose.yml << EOF
   archival-node:
-    build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-node
-    image: \${NODE_ORG}/node:\${NODE_TAG}
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
     restart: unless-stopped
     ports:
       - "30333:30333"
       - "30433:30433"
+      - "9615:9615"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
@@ -80,6 +80,8 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 for (( i = 0; i < node_count; i++ )); do

--- a/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  caddy_data: {}
+  archival_node_data: {}
+
+services:
+  # caddy reverse proxy with automatic tls management using let encrypt
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - CADDY_INGRESS_NETWORKS=subspace_default
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - caddy_data:/data
+
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+      - "40333:40333"
+    labels:
+      caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
+      caddy_0.handle_path_0: /ws
+      caddy_0.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
+      caddy_1: \${DOMAIN_PREFIX}-\${DOMAIN_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
+      caddy_1.handle_path_0: /ws
+      caddy_1.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+enable_domains=${5}
+domain_id=${6}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+#// TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == "true" ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${enable_domains}" == "true" ]; then
+    {
+    # core domain
+      echo '      "--",'
+      echo '      "--chain=${NETWORK_NAME}",'
+    #  echo '      "--enable-subspace-block-relay",'
+      echo '      "--state-pruning", "archive",'
+      echo '      "--blocks-pruning", "archive",'
+      echo '      "--domain-id=${DOMAIN_ID}",'
+      echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
+      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",
+      echo '      "--rpc-cors", "all",'
+      echo '      "--rpc-port", "8944",'
+      echo '      "--unsafe-rpc-external",'
+      echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+    for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
+      addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_evm_keys.txt)
+      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    done
+
+    }  >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
@@ -10,7 +10,10 @@ volumes:
 
 services:
   archival-node:
-    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
     restart: unless-stopped
@@ -45,9 +48,8 @@ node_count=${2}
 current_node=${3}
 bootstrap_node_count=${4}
 dsn_bootstrap_node_count=${4}
-bootstrap_node_evm_count=${5}
-enable_domains=${6}
-domain_id=${7}
+enable_domains=${5}
+domain_id=${6}
 
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)

--- a/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
@@ -1,33 +1,16 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
 
 volumes:
-  caddy_data: {}
   archival_node_data: {}
 
 services:
-  # caddy reverse proxy with automatic tls management using let encrypt
-  caddy:
-    image: lucaslorentz/caddy-docker-proxy:latest
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    environment:
-      - CADDY_INGRESS_NETWORKS=subspace_default
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - caddy_data:/data
-
   archival-node:
-    build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-node
-    image: \${NODE_ORG}/node:\${NODE_TAG}
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
     restart: unless-stopped
@@ -35,13 +18,7 @@ services:
       - "30333:30333"
       - "30433:30433"
       - "40333:40333"
-    labels:
-      caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
-      caddy_0.handle_path_0: /ws
-      caddy_0.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
-      caddy_1: \${DOMAIN_PREFIX}-\${DOMAIN_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
-      caddy_1.handle_path_0: /ws
-      caddy_1.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
+      - "9615:9615"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
@@ -59,6 +36,8 @@ services:
       "--out-peers", "250",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 reserved_only=${1}
@@ -66,8 +45,9 @@ node_count=${2}
 current_node=${3}
 bootstrap_node_count=${4}
 dsn_bootstrap_node_count=${4}
-enable_domains=${5}
-domain_id=${6}
+bootstrap_node_evm_count=${5}
+enable_domains=${6}
+domain_id=${7}
 
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
@@ -96,16 +76,11 @@ if [ "${enable_domains}" == "true" ]; then
       echo '      "--blocks-pruning", "archive",'
       echo '      "--domain-id=${DOMAIN_ID}",'
       echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
-      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",
+      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",'
       echo '      "--rpc-cors", "all",'
       echo '      "--rpc-port", "8944",'
       echo '      "--unsafe-rpc-external",'
       echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
-    for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
-      addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_evm_keys.txt)
-      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-    done
 
     }  >> ~/subspace/docker-compose.yml
 fi

--- a/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  farmer_data: {}
+
+services:
+  farmer:
+    depends_on:
+      archival-node:
+        condition: service_healthy
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-farmer
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - /home/$USER/subspace/farmer_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30533:30533"
+    command: [
+      "farm", "path=/var/subspace,size=\${PLOT_SIZE}",
+      "--node-rpc-url", "ws://archival-node:9944",
+      "--external-address", "/ip4/$EXTERNAL_IP/tcp/30533",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30533",
+      "--reward-address", "\${REWARD_ADDRESS}",
+    ]
+
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--validator",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--rpc-methods", "unsafe",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+force_block_production=${5}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+  echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${force_block_production}" == true ]; then
+  echo "      \"--force-synced\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--force-authoring\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
@@ -42,6 +42,7 @@ services:
     ports:
       - "30333:30333"
       - "30433:30433"
+      - "9615:9615"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
@@ -54,9 +55,12 @@ services:
 #      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
       "--validator",
+      "--timekeeper",
       "--rpc-cors", "all",
       "--rpc-external",
       "--rpc-methods", "unsafe",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 reserved_only=${1}
@@ -75,7 +79,7 @@ done
 # // TODO: make configurable with gemini network
 for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
   dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
-  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
   echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
 done
 

--- a/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
@@ -15,8 +15,8 @@ services:
       archival-node:
         condition: service_healthy
     build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-farmer
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-farmer
     image: \${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - /home/$USER/subspace/farmer_data:/var/subspace:rw

--- a/testing-framework/ec2/base/scripts/create_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_node_compose_file.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
 
 volumes:
-  caddy_data: {}
   archival_node_data: {}
 
 services:
@@ -18,23 +17,31 @@ services:
     volumes:
       - archival_node_data:/var/subspace:rw
     restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+      - "9615:9615"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--execution", "wasm",
 #      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
-      "--blocks-pruning", "archive",
+      "--blocks-pruning", "256",
       "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
 #      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
-      "--rpc-cors", "all",
-      "--rpc-external",
-      "--in-peers", "500",
-      "--out-peers", "250",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 reserved_only=${1}
@@ -52,7 +59,7 @@ done
 # // TODO: make configurable with gemini network as it's not needed for devnet
 for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
   dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
-  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
   echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
 done
 

--- a/testing-framework/ec2/base/scripts/create_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_node_compose_file.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  caddy_data: {}
+  archival_node_data: {}
+
+services:
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/ec2/base/scripts/create_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_node_compose_file.sh
@@ -11,8 +11,8 @@ volumes:
 services:
   archival-node:
     build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-node
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
     image: \${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
@@ -39,7 +39,6 @@ services:
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
       "--in-peers-light", "500",
-      "--rpc-max-connections", "10000",
       "--prometheus-port", "9615",
       "--prometheus-external",
 EOF

--- a/testing-framework/ec2/base/scripts/installer.sh
+++ b/testing-framework/ec2/base/scripts/installer.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# updates
+export DEBIAN_FRONTEND=noninteractive
+sudo apt update -y
+sudo apt install -y curl jq git
+
+# install docker & Docker Compose
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+
+# set max socket connections
+if ! (grep -iq "net.core.somaxconn" /etc/sysctl.conf && sed -i 's/.*net.core.somaxconn.*/net.core.somaxconn=65535/' /etc/sysctl.conf); then
+  sudo echo "net.core.somaxconn=65535" >> /etc/sysctl.conf
+fi
+
+sudo sysctl -p /etc/sysctl.conf

--- a/testing-framework/ec2/base/scripts/prune_docker_system.sh
+++ b/testing-framework/ec2/base/scripts/prune_docker_system.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo docker ps -aq | xargs sudo docker update --restart=no
+# stop all the containers
+sudo docker compose down
+# prune everything docker related
+sudo docker system prune -a -f
+sudo docker volume ls -q | grep -v caddy | xargs sudo docker volume rm -f
+# remove key files
+sudo rm -rf ~/subspace/*_keys.txt

--- a/testing-framework/ec2/base/variables.tf
+++ b/testing-framework/ec2/base/variables.tf
@@ -21,7 +21,7 @@ variable "instance_count" {
   default = {
     bootstrap = 2
     node      = 1
-    domain    = 1
+    domain    = 0
     farmer    = 1
   }
 }
@@ -58,8 +58,7 @@ variable "aws_key_name" {
 }
 
 variable "ssh_user" {
-  default = "ubuntu"
-  type    = string
+  type = string
 }
 
 variable "private_key_path" {
@@ -158,4 +157,9 @@ variable "secret_key" {
 variable "access_key" {
   type      = string
   sensitive = true
+}
+
+variable "branch_name" {
+  description = "name of testing branch"
+  type        = string
 }

--- a/testing-framework/ec2/base/variables.tf
+++ b/testing-framework/ec2/base/variables.tf
@@ -1,0 +1,161 @@
+variable "instance_type" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  type = string
+}
+
+variable "azs" {
+  type        = string
+  description = "Availability Zones"
+  default     = "us-west-2a"
+}
+
+variable "instance_count" {
+  type = map(number)
+  default = {
+    bootstrap = 2
+    node      = 1
+    domain    = 1
+    farmer    = 1
+  }
+}
+
+variable "aws_region" {
+  description = "aws region"
+  type        = list(string)
+  default     = ["us-west-2"]
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public Subnet CIDR values"
+}
+
+variable "disk_volume_type" {
+  type    = string
+  default = "gp3"
+}
+
+variable "network_name" {
+  description = "Network name"
+  type        = string
+}
+
+variable "path_to_scripts" {
+  description = "Path to the scripts"
+  type        = string
+}
+
+variable "aws_key_name" {
+  default = "deployer"
+  type    = string
+}
+
+variable "ssh_user" {
+  default = "ubuntu"
+  type    = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/deployer.pem"
+}
+
+variable "piece_cache_size" {
+  description = "Piece cache size"
+  type        = string
+  default     = "1GiB"
+}
+
+variable "node-config" {
+  description = "Full node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    reserved-only      = bool
+    prune              = bool
+    node-dsn-port      = number
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "domain-node-config" {
+  description = "Domain node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    domain-prefix      = string
+    reserved-only      = bool
+    prune              = bool
+    node-dsn-port      = number
+    enable-domains     = bool
+    domain-id          = list(number)
+    domain-labels      = list(string)
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "bootstrap-node-config" {
+  description = "Bootstrap node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    reserved-only      = bool
+    prune              = bool
+    genesis-hash       = string
+    dsn-listen-port    = number
+    node-dsn-port      = number
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "farmer-node-config" {
+  description = "Farmer and Node configuration"
+  type = object({
+    instance-type          = string
+    deployment-version     = number
+    regions                = list(string)
+    instance-count         = number
+    docker-org             = string
+    docker-tag             = string
+    reserved-only          = bool
+    prune                  = bool
+    plot-size              = string
+    reward-address         = string
+    force-block-production = bool
+    node-dsn-port          = number
+    disk-volume-size       = number
+    disk-volume-type       = string
+  })
+}
+
+variable "secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "access_key" {
+  type      = string
+  sensitive = true
+}

--- a/testing-framework/ec2/network/backend.tf
+++ b/testing-framework/ec2/network/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "subspace-sre"
+
+    workspaces {
+      name = "ephemeral-devnet"
+    }
+  }
+}

--- a/testing-framework/ec2/network/main.tf
+++ b/testing-framework/ec2/network/main.tf
@@ -2,6 +2,7 @@ module "network" {
   source          = "../base"
   path_to_scripts = "../base/scripts"
   network_name    = var.network_name
+  branch_name     = var.branch_name
 
   bootstrap-node-config = {
     instance-type      = var.instance_type
@@ -10,7 +11,7 @@ module "network" {
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
     docker-tag         = "bootstrap-node"
-    reserved-only      = true
+    reserved-only      = false
     prune              = false
     genesis-hash       = ""
     dsn-listen-port    = 30533
@@ -26,7 +27,7 @@ module "network" {
     instance-count     = var.instance_count["node"]
     docker-org         = "subspace"
     docker-tag         = "subspace-node"
-    reserved-only      = true
+    reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
     disk-volume-size   = var.disk_volume_size
@@ -41,10 +42,10 @@ module "network" {
     docker-org         = "subspace"
     docker-tag         = "subspace-node"
     domain-prefix      = "domain"
-    reserved-only      = true
+    reserved-only      = false
     prune              = false
     node-dsn-port      = 30434
-    enable-domains     = true
+    enable-domains     = false
     domain-id          = var.domain_id
     domain-labels      = var.domain_labels
     disk-volume-size   = var.disk_volume_size
@@ -58,11 +59,11 @@ module "network" {
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
     docker-tag             = "farmer-node"
-    reserved-only          = true
+    reserved-only          = false
     prune                  = false
     plot-size              = "10G"
     reward-address         = var.farmer_reward_address
-    force-block-production = true
+    force-block-production = false
     node-dsn-port          = 30433
     disk-volume-size       = var.disk_volume_size
     disk-volume-type       = var.disk_volume_type

--- a/testing-framework/ec2/network/main.tf
+++ b/testing-framework/ec2/network/main.tf
@@ -1,0 +1,79 @@
+module "network" {
+  source          = "../base"
+  path_to_scripts = "../base/scripts"
+  network_name    = var.network_name
+
+  bootstrap-node-config = {
+    instance-type      = var.instance_type
+    deployment-version = 1
+    regions            = var.aws_region
+    instance-count     = var.instance_count["bootstrap"]
+    docker-org         = "subspace"
+    docker-tag         = "bootstrap-node"
+    reserved-only      = true
+    prune              = false
+    genesis-hash       = ""
+    dsn-listen-port    = 30533
+    node-dsn-port      = 30433
+    disk-volume-size   = var.disk_volume_size
+    disk-volume-type   = var.disk_volume_type
+  }
+
+  node-config = {
+    instance-type      = var.instance_type
+    deployment-version = 1
+    regions            = var.aws_region
+    instance-count     = var.instance_count["node"]
+    docker-org         = "subspace"
+    docker-tag         = "subspace-node"
+    reserved-only      = true
+    prune              = false
+    node-dsn-port      = 30433
+    disk-volume-size   = var.disk_volume_size
+    disk-volume-type   = var.disk_volume_type
+  }
+
+  domain-node-config = {
+    instance-type      = var.instance_type
+    deployment-version = 1
+    regions            = var.aws_region
+    instance-count     = var.instance_count["domain"]
+    docker-org         = "subspace"
+    docker-tag         = "subspace-node"
+    domain-prefix      = "domain"
+    reserved-only      = true
+    prune              = false
+    node-dsn-port      = 30434
+    enable-domains     = true
+    domain-id          = var.domain_id
+    domain-labels      = var.domain_labels
+    disk-volume-size   = var.disk_volume_size
+    disk-volume-type   = var.disk_volume_type
+  }
+
+  farmer-node-config = {
+    instance-type          = var.instance_type
+    deployment-version     = 1
+    regions                = var.aws_region
+    instance-count         = var.instance_count["farmer"]
+    docker-org             = "subspace"
+    docker-tag             = "farmer-node"
+    reserved-only          = true
+    prune                  = false
+    plot-size              = "10G"
+    reward-address         = var.farmer_reward_address
+    force-block-production = true
+    node-dsn-port          = 30433
+    disk-volume-size       = var.disk_volume_size
+    disk-volume-type       = var.disk_volume_type
+
+  }
+
+  access_key          = var.access_key
+  secret_key          = var.secret_key
+  vpc_id              = var.vpc_id
+  instance_type       = var.instance_type
+  vpc_cidr_block      = var.vpc_cidr_block
+  public_subnet_cidrs = var.public_subnet_cidrs
+
+}

--- a/testing-framework/ec2/network/outputs.tf
+++ b/testing-framework/ec2/network/outputs.tf
@@ -1,0 +1,21 @@
+//output
+output "node-ipv4-addresses" {
+  value       = module.network.node_public_ip
+  description = "Subspace node IPv4 Addresses"
+}
+
+output "farmer-node-ipv4-addresses" {
+  value       = module.network.farmer_node_public_ip
+  description = "Farmer node IPv4 Addresses"
+}
+
+output "bootstrap-node-ipv4-addresses" {
+  value       = module.network.bootstrap_node_public_ip
+  description = "Bootstrap node IPv4 Addresses"
+}
+
+
+output "domain-node-ipv4-addresses" {
+  value       = module.network.domain_node_public_ip
+  description = "Domain node IPv4 Addresses"
+}

--- a/testing-framework/ec2/network/terraform.tfvars.example
+++ b/testing-framework/ec2/network/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# AWS access key used to create infrastructure
+access_key = ""
+# AWS secret key used to create AWS infrastructure
+secret_key          = ""
+vpc_id              = "ephemeral-vpc"
+vpc_cidr_block      = "172.31.0.0/16"
+public_subnet_cidrs = ["172.31.1.0/24"]
+aws_key_name        = "deployer"
+ssh_user            = "ubuntu"
+instance_type       = "m6a.xlarge"
+disk_volume_size    = 100
+tf_token            = ""
+branch_name         = "value"

--- a/testing-framework/ec2/network/variables.tf
+++ b/testing-framework/ec2/network/variables.tf
@@ -25,6 +25,7 @@ variable "instance_type" {
 variable "network_name" {
   description = "Network name"
   type        = string
+  default     = "ephemeral-devnet"
 }
 
 variable "branch_name" {

--- a/testing-framework/ec2/network/variables.tf
+++ b/testing-framework/ec2/network/variables.tf
@@ -1,0 +1,102 @@
+variable "farmer_reward_address" {
+  description = "Farmer's reward address"
+  type        = string
+}
+
+//todo change this to a map
+variable "domain_id" {
+  description = "Domain ID"
+  type        = list(number)
+  default     = [3]
+}
+
+//todo change this to a map
+variable "domain_labels" {
+  description = "Tag of the domain to run"
+  type        = list(string)
+  default     = ["evm"]
+}
+
+variable "instance_type" {
+  default = "m6a.xlarge"
+  type    = string
+}
+
+variable "network_name" {
+  description = "Network name"
+  type        = string
+}
+
+variable "branch_name" {
+  description = "name of testing branch"
+  type        = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  type = string
+}
+
+variable "azs" {
+  type        = string
+  description = "Availability Zones"
+  default     = "us-west-2a"
+}
+
+variable "instance_count" {
+  type = map(number)
+  default = {
+    bootstrap = 2
+    node      = 1
+    farmer    = 0
+  }
+}
+
+variable "aws_region" {
+  description = "aws region"
+  type        = list(string)
+  default     = ["us-west-2"]
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public Subnet CIDR values"
+  default     = ["172.31.1.0/24"]
+}
+
+variable "disk_volume_size" {
+  type = number
+}
+
+variable "disk_volume_type" {
+  type    = string
+  default = "gp3"
+}
+
+variable "secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "aws_key_name" {
+  default = "deployer"
+  type    = string
+}
+
+variable "ssh_user" {
+  default = "ubuntu"
+  type    = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/deployer.pem"
+}

--- a/testing-framework/hetzner/base/bootstrap_node_provisioner.tf
+++ b/testing-framework/hetzner/base/bootstrap_node_provisioner.tf
@@ -1,0 +1,157 @@
+locals {
+  bootstrap_nodes_ip_v4 = flatten([
+    [var.bootstrap-node-config.additional-node-ips]
+    ]
+  )
+}
+
+resource "null_resource" "setup-bootstrap-nodes" {
+  count = length(local.bootstrap_nodes_ip_v4)
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.bootstrap_nodes_ip_v4)
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /root/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /root/subspace/ && sudo chmod -R 750 /root/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/root/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/subspace/installer.sh",
+      "sudo bash /root/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /root/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-bootstrap-nodes" {
+  count      = var.bootstrap-node-config.prune ? length(local.bootstrap_nodes_ip_v4) : 0
+  depends_on = [null_resource.setup-bootstrap-nodes]
+
+  triggers = {
+    prune = var.bootstrap-node-config.prune
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/root/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/subspace/prune_docker_system.sh",
+      "sudo bash /root/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-boostrap-nodes" {
+  count = length(local.bootstrap_nodes_ip_v4)
+
+  depends_on = [null_resource.setup-bootstrap-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.bootstrap-node-config.deployment-version
+    reserved_only      = var.bootstrap-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy bootstrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/root/subspace/node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/root/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_bootstrap_node_compose_file.sh"
+    destination = "/root/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /root/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-bootstrap-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.bootstrap-node-config.docker-org} > /root/subspace/.env",
+      "echo NODE_TAG=${var.bootstrap-node-config.docker-tag} >> /root/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /root/subspace/.env",
+      "echo NODE_ID=${count.index} >> /root/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /root/subspace/node_keys.txt) >> /root/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /root/subspace/.env",
+      "echo DSN_NODE_ID=${count.index} >> /root/subspace/.env",
+      "echo DSN_NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /root/subspace/dsn_bootstrap_node_keys.txt) >> /root/subspace/.env",
+      "echo DSN_LISTEN_PORT=${var.bootstrap-node-config.dsn-listen-port} >> /root/subspace/.env",
+      "echo NODE_DSN_PORT=${var.bootstrap-node-config.node-dsn-port} >> /root/subspace/.env",
+      "echo GENESIS_HASH=${var.bootstrap-node-config.genesis-hash} >> /root/subspace/.env",
+
+      # create docker compose file
+      "chmod +x /root/subspace/create_compose_file.sh",
+      "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.bootstrap_nodes_ip_v4)} ${count.index}",
+
+      # start subspace node
+      # "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/testing-framework/hetzner/base/bootstrap_node_provisioner.tf
+++ b/testing-framework/hetzner/base/bootstrap_node_provisioner.tf
@@ -151,7 +151,7 @@ resource "null_resource" "start-boostrap-nodes" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.bootstrap_nodes_ip_v4)} ${count.index}",
 
       # start subspace node
-      # "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
+      "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
     ]
   }
 }

--- a/testing-framework/hetzner/base/domain_node_provisioner.tf
+++ b/testing-framework/hetzner/base/domain_node_provisioner.tf
@@ -1,0 +1,198 @@
+locals {
+  domain_node_ip_v4 = flatten([
+    [var.domain-node-config.additional-node-ips]
+    ]
+  )
+}
+
+resource "null_resource" "setup-domain-nodes" {
+  count = length(local.domain_node_ip_v4)
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.domain_node_ip_v4)
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /root/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /root/subspace/ && sudo chmod -R 750 /root/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/root/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /root/subspace/installer.sh",
+    ]
+  }
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /root/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-domain-nodes" {
+  count      = var.domain-node-config.prune ? length(local.domain_node_ip_v4) : 0
+  depends_on = [null_resource.setup-domain-nodes]
+
+  triggers = {
+    prune = var.domain-node-config.prune
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/root/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /root/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-domain-nodes" {
+  count = length(local.domain_node_ip_v4)
+
+  depends_on = [null_resource.setup-domain-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.domain-node-config.deployment-version
+    reserved_only      = var.domain-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./domain_node_keys.txt"
+    destination = "/root/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/root/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy dsn_boostrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/root/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy keystore
+  provisioner "file" {
+    source      = "./keystore"
+    destination = "/root/subspace/keystore/"
+  }
+
+  # copy relayer ids
+  provisioner "file" {
+    source      = "./relayer_ids.txt"
+    destination = "/root/subspace/relayer_ids.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_domain_node_compose_file.sh"
+    destination = "/root/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /root/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-domain-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.domain-node-config.docker-org} > /root/subspace/.env",
+      "echo NODE_TAG=${var.domain-node-config.docker-tag} >> /root/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /root/subspace/.env",
+      "echo DOMAIN_PREFIX=${var.domain-node-config.domain-prefix} >> /root/subspace/.env",
+      # //todo use a map for domain id and labels
+      "echo DOMAIN_LABEL=${var.domain-node-config.domain-labels[0]} >> /root/subspace/.env",
+      "echo DOMAIN_ID=${var.domain-node-config.domain-id[0]} >> /root/subspace/.env",
+      "echo NODE_ID=${count.index} >> /root/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /root/subspace/node_keys.txt) >> /root/subspace/.env",
+      "echo RELAYER_SYSTEM_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_SYSTEM_ID=//p' /root/subspace/relayer_ids.txt) >> /root/subspace/.env",
+      "echo RELAYER_DOMAIN_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_DOMAIN_ID=//p' /root/subspace/relayer_ids.txt) >> /root/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /root/subspace/.env",
+      "echo NODE_DSN_PORT=${var.domain-node-config.node-dsn-port} >> /root/subspace/.env",
+
+      # create docker compose file
+      "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.domain_node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains} ${var.domain-node-config.domain-id[0]}",
+
+      # start subspace node
+      "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
+    ]
+  }
+}
+
+resource "null_resource" "inject-domain-keystore" {
+  # for now we have one executor running. Should change here when multiple executors are expected.
+  count      = length(local.domain_node_ip_v4) > 0 ? 1 : 0
+  depends_on = [null_resource.start-domain-nodes]
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.domain-node-config.deployment-version
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[0]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo docker cp /root/subspace/keystore/.  subspace-archival-node-1:/var/subspace/keystore/"
+    ]
+  }
+}

--- a/testing-framework/hetzner/base/farmer_node_provisioner.tf
+++ b/testing-framework/hetzner/base/farmer_node_provisioner.tf
@@ -108,18 +108,6 @@ resource "null_resource" "start-farmer-nodes" {
     timeout     = "300s"
   }
 
-  # copy farmer identity files
-  provisioner "file" {
-    source      = "./identity.bin"
-    destination = "/root/subspace/farmer_data/identity.bin"
-  }
-
-  provisioner "file" {
-    source      = "./single_disk_plot.json"
-    destination = "/root/subspace/farmer_data/single_disk_plot.json"
-  }
-
-
   # copy boostrap node keys file
   provisioner "file" {
     source      = "./bootstrap_node_keys.txt"

--- a/testing-framework/hetzner/base/farmer_node_provisioner.tf
+++ b/testing-framework/hetzner/base/farmer_node_provisioner.tf
@@ -1,0 +1,169 @@
+locals {
+  farmer_node_ipv4 = flatten([
+    [var.farmer-node-config.additional-node-ips]
+    ]
+  )
+}
+
+resource "null_resource" "setup-farmer-nodes" {
+  count = length(local.farmer_node_ipv4)
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.farmer_node_ipv4)
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /root/subspace/",
+      "sudo mkdir -p /root/subspace/farmer_data/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /root/subspace/ && sudo chmod -R 750 /root/subspace/",
+      "sudo chown -R nobody:nogroup /root/subspace/farmer_data/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/root/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/subspace/installer.sh",
+      "sudo /root/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /root/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-farmer-nodes" {
+  count      = var.farmer-node-config.prune ? length(local.farmer_node_ipv4) : 0
+  depends_on = [null_resource.setup-farmer-nodes]
+
+  triggers = {
+    prune = var.farmer-node-config.prune
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/root/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/subspace/prune_docker_system.sh",
+      "sudo bash /root/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-farmer-nodes" {
+  count = length(local.farmer_node_ipv4)
+
+  depends_on = [null_resource.setup-farmer-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.farmer-node-config.deployment-version
+    reserved_only      = var.farmer-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy farmer identity files
+  provisioner "file" {
+    source      = "./identity.bin"
+    destination = "/root/subspace/farmer_data/identity.bin"
+  }
+
+  provisioner "file" {
+    source      = "./single_disk_plot.json"
+    destination = "/root/subspace/farmer_data/single_disk_plot.json"
+  }
+
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/root/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/root/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_farmer_node_compose_file.sh"
+    destination = "/root/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /root/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-farmer-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.farmer-node-config.docker-org} > /root/subspace/.env",
+      "echo NODE_TAG=${var.farmer-node-config.docker-tag} >> /root/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /root/subspace/.env",
+      "echo NODE_ID=${count.index} >> /root/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /root/subspace/node_keys.txt) >> /root/subspace/.env",
+      "echo REWARD_ADDRESS=${var.farmer-node-config.reward-address} >> /root/subspace/.env",
+      "echo PLOT_SIZE=${var.farmer-node-config.plot-size} >> /root/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /root/subspace/.env",
+      "echo NODE_DSN_PORT=${var.farmer-node-config.node-dsn-port} >> /root/subspace/.env",
+
+      # create docker compose file
+      "chmod +x /root/subspace/create_compose_file.sh",
+      "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
+
+      # start subspace
+      # "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/testing-framework/hetzner/base/farmer_node_provisioner.tf
+++ b/testing-framework/hetzner/base/farmer_node_provisioner.tf
@@ -151,7 +151,7 @@ resource "null_resource" "start-farmer-nodes" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
 
       # start subspace
-      # "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
+      "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
     ]
   }
 }

--- a/testing-framework/hetzner/base/node_provisioner.tf
+++ b/testing-framework/hetzner/base/node_provisioner.tf
@@ -1,0 +1,159 @@
+locals {
+  node_ip_v4 = flatten([
+    [var.node-config.additional-node-ips]
+    ]
+  )
+}
+
+resource "null_resource" "setup-nodes" {
+  count = length(local.node_ip_v4)
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.node_ip_v4)
+  }
+
+  connection {
+    host        = local.node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /root/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /root/subspace/ && sudo chmod -R 750 /root/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/root/subspace/installer.sh"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/subspace/installer.sh",
+      "sudo bash /root/subspace/installer.sh",
+    ]
+  }
+
+  # clone testing branch
+  provisioner "remote-exec" {
+    inline = [
+      "cd /root/subspace/",
+      "git clone https://github.com/subspace/subspace.git",
+      "git checkout ${var.branch_name}"
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-nodes" {
+  count      = var.node-config.prune ? length(local.node_ip_v4) : 0
+  depends_on = [null_resource.setup-nodes]
+
+  triggers = {
+    prune = var.node-config.prune
+  }
+
+  connection {
+    host        = local.node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/root/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /root/subspace/prune_docker_system.sh",
+      "sudo bash /root/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-nodes" {
+  count = length(local.node_ip_v4)
+
+  depends_on = [null_resource.setup-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.node-config.deployment-version
+    reserved_only      = var.node-config.reserved-only
+  }
+
+  connection {
+    host        = local.node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./node_keys.txt"
+    destination = "/root/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/root/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/root/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_node_compose_file.sh"
+    destination = "/root/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /root/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.node-config.docker-org} > /root/subspace/.env",
+      "echo NODE_TAG=${var.node-config.docker-tag} >> /root/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /root/subspace/.env",
+      "echo NODE_ID=${count.index} >> /root/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /root/subspace/node_keys.txt) >> /root/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /root/subspace/.env",
+      "echo NODE_DSN_PORT=${var.node-config.node-dsn-port} >> /root/subspace/.env",
+
+      # create docker compose file
+      "chmod +x /root/subspace/create_compose_file.sh",
+      "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)}",
+
+      # start subspace node
+      "sudo docker compose -f /root/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/testing-framework/hetzner/base/outputs.tf
+++ b/testing-framework/hetzner/base/outputs.tf
@@ -1,0 +1,19 @@
+output "node-ipv4-addresses" {
+  value       = local.node_ip_v4
+  description = "Subspace node IPv4 Addresses"
+}
+
+output "farmer-node-ipv4-addresses" {
+  value       = local.farmer_node_ipv4
+  description = "Farmer node IPv4 Addresses"
+}
+
+output "bootstrap-node-ipv4-addresses" {
+  value       = local.bootstrap_nodes_ip_v4
+  description = "Bootstrap node IPv4 Addresses"
+}
+
+output "domain-node-ipv4-addresses" {
+  value       = local.domain_node_ip_v4
+  description = "domain node IPv4 Addresses"
+}

--- a/testing-framework/hetzner/base/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/hetzner/base/scripts/create_bootstrap_node_compose_file.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+
+services:
+  dsn-bootstrap-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-bootstrap-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=info
+    ports:
+      - "30533:30533"
+    command:
+      - start
+      - \${DSN_NODE_KEY}
+      - /ip4/0.0.0.0/tcp/30533
+      - --protocol-version
+      - \${GENESIS_HASH}
+      - "--in-peers"
+      - "1000"
+      - "--out-peers"
+      - "1000"
+      - "--pending-in-peers"
+      - "1000"
+      - "--pending-out-peers"
+      - "1000"
+      - "--external-address"
+      - "/ip4/$EXTERNAL_IP/tcp/30533"
+EOF
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--reserved-peers\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"--bootstrap-nodes\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+cat >> ~/subspace/docker-compose.yml << EOF
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--in-peers-light", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+    echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  fi
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/hetzner/base/scripts/create_domain_node_compose_file.sh
+++ b/testing-framework/hetzner/base/scripts/create_domain_node_compose_file.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  caddy_data: {}
+  archival_node_data: {}
+
+services:
+  # caddy reverse proxy with automatic tls management using let encrypt
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - CADDY_INGRESS_NETWORKS=subspace_default
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - caddy_data:/data
+
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+      - "40333:40333"
+    labels:
+      caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
+      caddy_0.handle_path_0: /ws
+      caddy_0.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
+      caddy_1: \${DOMAIN_PREFIX}-\${DOMAIN_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
+      caddy_1.handle_path_0: /ws
+      caddy_1.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+enable_domains=${5}
+domain_id=${6}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+#// TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == "true" ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${enable_domains}" == "true" ]; then
+    {
+    # core domain
+      echo '      "--",'
+      echo '      "--chain=${NETWORK_NAME}",'
+    #  echo '      "--enable-subspace-block-relay",'
+      echo '      "--state-pruning", "archive",'
+      echo '      "--blocks-pruning", "archive",'
+      echo '      "--domain-id=${DOMAIN_ID}",'
+      echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
+      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",
+      echo '      "--rpc-cors", "all",'
+      echo '      "--rpc-port", "8944",'
+      echo '      "--unsafe-rpc-external",'
+      echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+    for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
+      addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_evm_keys.txt)
+      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    done
+
+    }  >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/hetzner/base/scripts/create_domain_node_compose_file.sh
+++ b/testing-framework/hetzner/base/scripts/create_domain_node_compose_file.sh
@@ -1,32 +1,18 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
 
 volumes:
-  caddy_data: {}
   archival_node_data: {}
 
 services:
-  # caddy reverse proxy with automatic tls management using let encrypt
-  caddy:
-    image: lucaslorentz/caddy-docker-proxy:latest
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    environment:
-      - CADDY_INGRESS_NETWORKS=subspace_default
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - caddy_data:/data
-
   archival-node:
     build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-node
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
     image: \${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
@@ -35,13 +21,7 @@ services:
       - "30333:30333"
       - "30433:30433"
       - "40333:40333"
-    labels:
-      caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
-      caddy_0.handle_path_0: /ws
-      caddy_0.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
-      caddy_1: \${DOMAIN_PREFIX}-\${DOMAIN_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
-      caddy_1.handle_path_0: /ws
-      caddy_1.handle_path_0.reverse_proxy: "{{upstreams 8944}}"
+      - "9615:9615"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
@@ -59,6 +39,8 @@ services:
       "--out-peers", "250",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 reserved_only=${1}
@@ -96,16 +78,11 @@ if [ "${enable_domains}" == "true" ]; then
       echo '      "--blocks-pruning", "archive",'
       echo '      "--domain-id=${DOMAIN_ID}",'
       echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
-      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",
+      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",'
       echo '      "--rpc-cors", "all",'
       echo '      "--rpc-port", "8944",'
       echo '      "--unsafe-rpc-external",'
       echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
-    for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
-      addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_evm_keys.txt)
-      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-    done
 
     }  >> ~/subspace/docker-compose.yml
 fi

--- a/testing-framework/hetzner/base/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/hetzner/base/scripts/create_farmer_node_compose_file.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  farmer_data: {}
+
+services:
+  farmer:
+    depends_on:
+      archival-node:
+        condition: service_healthy
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-farmer
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - /home/$USER/subspace/farmer_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30533:30533"
+    command: [
+      "farm", "path=/var/subspace,size=\${PLOT_SIZE}",
+      "--node-rpc-url", "ws://archival-node:9944",
+      "--external-address", "/ip4/$EXTERNAL_IP/tcp/30533",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30533",
+      "--reward-address", "\${REWARD_ADDRESS}",
+    ]
+
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--validator",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--rpc-methods", "unsafe",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+force_block_production=${5}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+  echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${force_block_production}" == true ]; then
+  echo "      \"--force-synced\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--force-authoring\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/hetzner/base/scripts/create_node_compose_file.sh
+++ b/testing-framework/hetzner/base/scripts/create_node_compose_file.sh
@@ -1,40 +1,47 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
 
 volumes:
-  caddy_data: {}
   archival_node_data: {}
 
 services:
   archival-node:
     build:
-      context: $HOME/subspace/subspace/
-      dockerfile: Dockerfile-node
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
     image: \${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
     restart: unless-stopped
+    ports:
+      - "30333:30333"
+      - "30433:30433"
+      - "9615:9615"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--execution", "wasm",
 #      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
-      "--blocks-pruning", "archive",
+      "--blocks-pruning", "256",
       "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
 #      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
-      "--rpc-cors", "all",
-      "--rpc-external",
-      "--in-peers", "500",
-      "--out-peers", "250",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 reserved_only=${1}
@@ -52,7 +59,7 @@ done
 # // TODO: make configurable with gemini network as it's not needed for devnet
 for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
   dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
-  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
   echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
 done
 

--- a/testing-framework/hetzner/base/scripts/create_node_compose_file.sh
+++ b/testing-framework/hetzner/base/scripts/create_node_compose_file.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  caddy_data: {}
+  archival_node_data: {}
+
+services:
+  archival-node:
+    build:
+      context: $HOME/subspace/subspace/
+      dockerfile: Dockerfile-node
+    image: \${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn)addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/testing-framework/hetzner/base/scripts/installer.sh
+++ b/testing-framework/hetzner/base/scripts/installer.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# updates
+export DEBIAN_FRONTEND=noninteractive
+sudo apt update -y
+sudo apt install -y curl jq git
+
+# install docker & Docker Compose
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+
+# set max socket connections
+if ! (grep -iq "net.core.somaxconn" /etc/sysctl.conf && sed -i 's/.*net.core.somaxconn.*/net.core.somaxconn=65535/' /etc/sysctl.conf); then
+  sudo echo "net.core.somaxconn=65535" >> /etc/sysctl.conf
+fi
+
+sudo sysctl -p /etc/sysctl.conf

--- a/testing-framework/hetzner/base/scripts/prune_docker_system.sh
+++ b/testing-framework/hetzner/base/scripts/prune_docker_system.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo docker ps -aq | xargs sudo docker update --restart=no
+# stop all the containers
+sudo docker compose down
+# prune everything docker related
+sudo docker system prune -a -f
+sudo docker volume ls -q | grep -v caddy | xargs sudo docker volume rm -f
+# remove key files
+sudo rm -rf ~/subspace/*_keys.txt

--- a/testing-framework/hetzner/base/variables.tf
+++ b/testing-framework/hetzner/base/variables.tf
@@ -1,0 +1,100 @@
+variable "network_name" {
+  description = "Network name"
+  type        = string
+}
+
+variable "path_to_scripts" {
+  description = "Path to the scripts"
+  type        = string
+}
+
+variable "piece_cache_size" {
+  description = "Piece cache size"
+  type        = string
+  default     = "1GiB"
+}
+
+variable "node-config" {
+  description = "Full node deployment config"
+  type = object({
+    deployment-version  = number
+    instance-count      = number
+    docker-org          = string
+    docker-tag          = string
+    additional-node-ips = list(string)
+    reserved-only       = bool
+    prune               = bool
+    node-dsn-port       = number
+  })
+}
+
+variable "domain-node-config" {
+  description = "Domain node deployment config"
+  type = object({
+    deployment-version  = number
+    instance-count      = number
+    docker-org          = string
+    docker-tag          = string
+    additional-node-ips = list(string)
+    domain-prefix       = string
+    reserved-only       = bool
+    prune               = bool
+    node-dsn-port       = number
+    enable-domains      = bool
+    domain-id           = list(number)
+    domain-labels       = list(string)
+  })
+}
+
+variable "bootstrap-node-config" {
+  description = "Bootstrap node deployment config"
+  type = object({
+    deployment-version  = number
+    instance-count      = number
+    docker-org          = string
+    docker-tag          = string
+    additional-node-ips = list(string)
+    reserved-only       = bool
+    prune               = bool
+    genesis-hash        = string
+    dsn-listen-port     = number
+    node-dsn-port       = number
+  })
+}
+
+variable "farmer-node-config" {
+  description = "Farmer and Node configuration"
+  type = object({
+    deployment-version     = number
+    instance-count         = number
+    docker-org             = string
+    docker-tag             = string
+    additional-node-ips    = list(string)
+    reserved-only          = bool
+    prune                  = bool
+    plot-size              = string
+    reward-address         = string
+    force-block-production = bool
+    node-dsn-port          = number
+  })
+}
+
+variable "ssh_key_name" {
+  default = "hetzner"
+  type    = string
+}
+
+variable "ssh_user" {
+  default = "root"
+  type    = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/hetzner"
+}
+
+variable "branch_name" {
+  description = "name of testing branch"
+  type        = string
+}

--- a/testing-framework/hetzner/network/backend.tf
+++ b/testing-framework/hetzner/network/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "subspace-sre"
+
+    workspaces {
+      name = "ephemeral-devnet-hetzner"
+    }
+  }
+}

--- a/testing-framework/hetzner/network/main.tf
+++ b/testing-framework/hetzner/network/main.tf
@@ -1,0 +1,60 @@
+module "network" {
+  source          = "../base"
+  path_to_scripts = "../base/scripts"
+  network_name    = var.network_name
+  branch_name     = var.branch_name
+
+  bootstrap-node-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["bootstrap"]
+    docker-org          = "subspace"
+    docker-tag          = "bootstrap-node"
+    additional-node-ips = var.additional_node_ips["bootstrap"]
+    reserved-only       = true
+    prune               = false
+    genesis-hash        = ""
+    dsn-listen-port     = 30533
+    node-dsn-port       = 30433
+  }
+
+  node-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["node"]
+    docker-org          = "subspace"
+    docker-tag          = "subspace-node"
+    additional-node-ips = var.additional_node_ips["node"]
+    reserved-only       = true
+    prune               = false
+    node-dsn-port       = 30433
+  }
+
+  domain-node-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["domain"]
+    docker-org          = "subspace"
+    docker-tag          = "subspace-node"
+    additional-node-ips = var.additional_node_ips["domain"]
+    domain-prefix       = "domain"
+    reserved-only       = true
+    prune               = false
+    node-dsn-port       = 30434
+    enable-domains      = true
+    domain-id           = var.domain_id
+    domain-labels       = var.domain_labels
+  }
+
+  farmer-node-config = {
+    deployment-version     = 1
+    instance-count         = var.instance_count["farmer"]
+    docker-org             = "subspace"
+    docker-tag             = "farmer-node"
+    additional-node-ips    = var.additional_node_ips["farmer"]
+    reserved-only          = true
+    prune                  = false
+    plot-size              = "10G"
+    reward-address         = var.farmer_reward_address
+    force-block-production = true
+    node-dsn-port          = 30433
+
+  }
+}

--- a/testing-framework/hetzner/network/outputs.tf
+++ b/testing-framework/hetzner/network/outputs.tf
@@ -1,0 +1,20 @@
+output "bootstrap-node-ipv4-addresses" {
+  value       = module.network.bootstrap-node-ipv4-addresses
+  description = "Bootstrap node IPv4 Addresses"
+}
+
+output "node-ipv4-addresses" {
+  value       = module.network.node-ipv4-addresses
+  description = "subspace node IPv4 Addresses"
+}
+
+output "domain-node-ipv4-addresses" {
+  value       = module.network.domain-node-ipv4-addresses
+  description = "domain node IPv4 Addresses"
+}
+
+
+output "farmer-nodes-ipv4-addresses" {
+  value       = module.network.farmer-node-ipv4-addresses
+  description = "Farmer node IPv4 Addresses"
+}

--- a/testing-framework/hetzner/network/terraform.tfvars.example
+++ b/testing-framework/hetzner/network/terraform.tfvars.example
@@ -1,0 +1,14 @@
+ssh_key_name = "hetzner"
+ssh_user     = "root"
+tf_token     = ""
+branch_name  = ""
+additional_node_ips = {
+  bootstrap = [""]
+  node      = [""]
+  farmer    = [""]
+}
+instance_count = {
+  bootstrap = 2
+  node      = 1
+  farmer    = 1
+}

--- a/testing-framework/hetzner/network/variables.tf
+++ b/testing-framework/hetzner/network/variables.tf
@@ -1,0 +1,71 @@
+variable "farmer_reward_address" {
+  description = "Farmer's reward address"
+  type        = string
+}
+
+variable "network_name" {
+  description = "Network name"
+  type        = string
+}
+
+//todo change this to a map
+variable "domain_id" {
+  description = "Domain ID"
+  type        = list(number)
+  default     = [3]
+}
+
+//todo change this to a map
+variable "domain_labels" {
+  description = "Tag of the domain to run"
+  type        = list(string)
+  default     = ["evm"]
+}
+
+variable "azs" {
+  type        = string
+  description = "Availability Zones"
+  default     = "us-east-1a"
+}
+
+variable "instance_count" {
+  type = map(number)
+  default = {
+    bootstrap = 2
+    node      = 1
+    farmer    = 0
+  }
+}
+
+variable "additional_node_ips" {
+  type = map(list(string))
+  default = {
+    bootstrap = [""]
+    node      = [""]
+    farmer    = [""]
+  }
+}
+
+variable "ssh_key_name" {
+  default = "hetzner"
+  type    = string
+}
+
+variable "ssh_user" {
+  default = "root"
+  type    = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/hetzner"
+}
+
+variable "tf_token" {
+  type = string
+}
+
+variable "branch_name" {
+  description = "name of testing branch"
+  type        = string
+}


### PR DESCRIPTION
This PR creates the ephemeral testing framework to spin up "devnets" for testing purposes.
- aws declarations
- hetzner declarations
- make docker compose files build from branch

Instances can spin up on AWS or re-use hetzner resources.

closes #167 