### PR TITLE
enable metrics monitoring

### DIFF
--- a/aws/gemini-3f/main.tf
+++ b/aws/gemini-3f/main.tf
@@ -1,6 +1,7 @@
 module "gemini-3f" {
   source          = "../network-primitives"
   path_to_scripts = "../network-primitives/scripts"
+  path_to_configs = "../network-primitives/configs"
   network_name    = "gemini-3f"
   bootstrap-node-config = {
     instance-type      = var.instance_type

--- a/aws/network-primitives/bootstrap_node_evm_provisioner.tf
+++ b/aws/network-primitives/bootstrap_node_evm_provisioner.tf
@@ -38,6 +38,12 @@ resource "null_resource" "setup-bootstrap-nodes-evm" {
     destination = "/home/${var.ssh_user}/subspace/installer.sh"
   }
 
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
   # install docker and docker compose
   provisioner "remote-exec" {
     inline = [

--- a/aws/network-primitives/bootstrap_node_provisioner.tf
+++ b/aws/network-primitives/bootstrap_node_provisioner.tf
@@ -38,6 +38,12 @@ resource "null_resource" "setup-bootstrap-nodes" {
     destination = "/home/${var.ssh_user}/subspace/installer.sh"
   }
 
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
   # install docker and docker compose
   provisioner "remote-exec" {
     inline = [

--- a/aws/network-primitives/configs/prometheus.yml
+++ b/aws/network-primitives/configs/prometheus.yml
@@ -1,0 +1,8 @@
+# A scrape configuration for subspace node:
+scrape_configs:
+  - job_name: "subspace_node"
+
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ["localhost:9615"]

--- a/aws/network-primitives/domain_node_provisioner.tf
+++ b/aws/network-primitives/domain_node_provisioner.tf
@@ -38,6 +38,12 @@ resource "null_resource" "setup-domain-nodes" {
     destination = "/home/${var.ssh_user}/subspace/installer.sh"
   }
 
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
   # install docker and docker compose
   provisioner "remote-exec" {
     inline = [

--- a/aws/network-primitives/farmer_node_provisioner.tf
+++ b/aws/network-primitives/farmer_node_provisioner.tf
@@ -40,6 +40,12 @@ resource "null_resource" "setup-farmer-nodes" {
     destination = "/home/${var.ssh_user}/subspace/installer.sh"
   }
 
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
   # install docker and docker compose
   provisioner "remote-exec" {
     inline = [

--- a/aws/network-primitives/full_node_provisioner.tf
+++ b/aws/network-primitives/full_node_provisioner.tf
@@ -38,6 +38,12 @@ resource "null_resource" "setup-full-nodes" {
     destination = "/home/${var.ssh_user}/subspace/installer.sh"
   }
 
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
   # install docker and docker compose
   provisioner "remote-exec" {
     inline = [

--- a/aws/network-primitives/rpc_node_provisioner.tf
+++ b/aws/network-primitives/rpc_node_provisioner.tf
@@ -38,6 +38,12 @@ resource "null_resource" "setup-rpc-nodes" {
     destination = "/home/${var.ssh_user}/subspace/installer.sh"
   }
 
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
   # install docker and docker compose
   provisioner "remote-exec" {
     inline = [

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -13,18 +13,21 @@ volumes:
   archival_node_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "bootstrap-node-${NODE_ID}"
+    restart: unless-stopped
 
   dsn-bootstrap-node:
     image: ghcr.io/\${NODE_ORG}/bootstrap-node:\${NODE_TAG}
@@ -33,6 +36,10 @@ services:
       - RUST_LOG=info
     ports:
       - "30533:30533"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
       - \${DSN_NODE_KEY}
@@ -69,6 +76,10 @@ cat >> ~/subspace/docker-compose.yml << EOF
     ports:
       - "30333:30333"
       - "30433:30433"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 reserved_only=${1}
 node_count=${2}
@@ -11,8 +11,23 @@ version: "3.7"
 
 volumes:
   archival_node_data: {}
+  vmagentdata: {}
 
 services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=https://vmetrics.subspace.network:8428/api/v1/write"
+
   agent:
     container_name: newrelic-infra
     image: newrelic/infrastructure:latest
@@ -76,6 +91,7 @@ cat >> ~/subspace/docker-compose.yml << EOF
     ports:
       - "30333:30333"
       - "30433:30433"
+      - "9615:9615"
     logging:
       driver: loki
       options:
@@ -98,6 +114,8 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 for (( i = 0; i < node_count; i++ )); do

--- a/aws/network-primitives/scripts/create_domain_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_domain_node_compose_file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXTERNAL_IP=`curl -s ifconfig.me`
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
@@ -8,8 +8,23 @@ version: "3.7"
 volumes:
   caddy_data: {}
   archival_node_data: {}
+  vmagentdata: {}
 
 services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=https://vmetrics.subspace.network:8428/api/v1/write"
+
   agent:
     container_name: newrelic-infra
     image: newrelic/infrastructure:latest
@@ -48,6 +63,7 @@ services:
       - "30333:30333"
       - "30433:30433"
       - "40333:40333"
+      - "9615:9615"
     labels:
       caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${DOMAIN_LABEL}.\${NETWORK_NAME}.subspace.network
       caddy_0.handle_path_0: /ws
@@ -76,6 +92,8 @@ services:
       "--out-peers", "250",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
 EOF
 
 reserved_only=${1}

--- a/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
@@ -10,18 +10,21 @@ volumes:
   farmer_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "farmer-node-${NODE_ID}"
+    restart: unless-stopped
 
   farmer:
     depends_on:
@@ -33,6 +36,10 @@ services:
     restart: unless-stopped
     ports:
       - "30533:30533"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "farm", "path=/var/subspace,size=\${PLOT_SIZE}",
       "--node-rpc-url", "ws://archival-node:9944",
@@ -49,6 +56,10 @@ services:
     ports:
       - "30333:30333"
       - "30433:30433"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_full_node_compose_file.sh
@@ -9,18 +9,21 @@ volumes:
   archival_node_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "full-node-${NODE_ID}"
+    restart: unless-stopped
 
   archival-node:
     image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
@@ -30,6 +33,10 @@ services:
     ports:
       - "30333:30333"
       - "30433:30433"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
@@ -10,18 +10,21 @@ volumes:
   archival_node_data: {}
 
 services:
-  datadog:
-    container_name: "datadog_agent"
-    image: gcr.io/datadoghq/agent:7
-    restart: unless-stopped
-    environment:
-      - DD_API_KEY=\${DATADOG_API_KEY}
-      - DD_SITE=datadoghq.com
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /etc/os-release:/host/etc/os-release:ro
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: ${NR_API_KEY}
+      NRIA_DISPLAY_NAME: "rpc-node-${NODE_ID}"
+    restart: unless-stopped
 
   # caddy reverse proxy with automatic tls management using let encrypt
   caddy:
@@ -45,6 +48,10 @@ services:
       caddy_0: \${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network
       caddy_0.handle_path_0: /ws
       caddy_0.handle_path_0.reverse_proxy: "{{upstreams 9944}}"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",

--- a/aws/network-primitives/variables.tf
+++ b/aws/network-primitives/variables.tf
@@ -83,6 +83,11 @@ variable "path_to_scripts" {
   type        = string
 }
 
+variable "path_to_configs" {
+  description = "Path to the configs"
+  type        = string
+}
+
 variable "piece_cache_size" {
   description = "Piece cache size"
   type        = string


### PR DESCRIPTION
enable metrics monitoring
- add vmagent for victoria metrics
- use vmagent as drop-in-replacement for prometheus
- turn on metrics endpoint for subspace node

closes #147 