### PR TITLE
Gemini 3g upgrade

### DIFF
--- a/aws/gemini-3g/main.tf
+++ b/aws/gemini-3g/main.tf
@@ -9,7 +9,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-17"
+    docker-tag         = "gemini-3g-2023-nov-18"
     reserved-only      = true
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -25,7 +25,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-17"
+    docker-tag         = "gemini-3g-2023-nov-18"
     reserved-only      = false
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -42,7 +42,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-17"
+    docker-tag         = "gemini-3g-2023-nov-18"
     reserved-only      = true
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-17"
+    docker-tag         = "gemini-3g-2023-nov-18"
     domain-prefix      = "rpc"
     reserved-only      = true
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-17"
+    docker-tag         = "gemini-3g-2023-nov-18"
     domain-prefix      = "nova"
     reserved-only      = true
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3g" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3g-2023-nov-17"
+    docker-tag             = "gemini-3g-2023-nov-18"
     reserved-only          = true
     prune                  = false
     plot-size              = "2G"

--- a/aws/gemini-3g/main.tf
+++ b/aws/gemini-3g/main.tf
@@ -9,7 +9,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-18"
+    docker-tag         = "gemini-3g-2023-nov-19"
     reserved-only      = true
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -25,7 +25,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-18"
+    docker-tag         = "gemini-3g-2023-nov-19"
     reserved-only      = false
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -42,7 +42,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-18"
+    docker-tag         = "gemini-3g-2023-nov-19"
     reserved-only      = true
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-18"
+    docker-tag         = "gemini-3g-2023-nov-19"
     domain-prefix      = "rpc"
     reserved-only      = true
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-18"
+    docker-tag         = "gemini-3g-2023-nov-19"
     domain-prefix      = "nova"
     reserved-only      = true
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3g" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3g-2023-nov-18"
+    docker-tag             = "gemini-3g-2023-nov-19"
     reserved-only          = true
     prune                  = false
     plot-size              = "2G"

--- a/aws/gemini-3g/main.tf
+++ b/aws/gemini-3g/main.tf
@@ -9,7 +9,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-15"
+    docker-tag         = "gemini-3g-2023-nov-17"
     reserved-only      = true
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -25,7 +25,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-15"
+    docker-tag         = "gemini-3g-2023-nov-17"
     reserved-only      = false
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -42,7 +42,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-15"
+    docker-tag         = "gemini-3g-2023-nov-17"
     reserved-only      = true
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-15"
+    docker-tag         = "gemini-3g-2023-nov-17"
     domain-prefix      = "rpc"
     reserved-only      = true
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2023-nov-15"
+    docker-tag         = "gemini-3g-2023-nov-17"
     domain-prefix      = "nova"
     reserved-only      = true
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3g" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3g-2023-nov-15"
+    docker-tag             = "gemini-3g-2023-nov-17"
     reserved-only          = true
     prune                  = false
     plot-size              = "2G"

--- a/aws/gemini-3g/variables.tf
+++ b/aws/gemini-3g/variables.tf
@@ -7,7 +7,7 @@ variable "farmer_reward_address" {
 variable "domain_id" {
   description = "Domain ID"
   type        = list(number)
-  default     = [0]
+  default     = [1]
 }
 
 //todo change this to a map
@@ -51,7 +51,7 @@ variable "instance_count" {
     rpc           = 2
     domain        = 2
     full          = 1
-    farmer        = 1
+    farmer        = 0
     evm_bootstrap = 1
   }
 }

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -77,7 +77,7 @@ services:
       - "1000"
       - "--pending-out-peers"
       - "1000"
-## comment external addresses using IP format for now
+## comment to disable external addresses using IP format for now
 #      - "--external-address"
 #      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
 #      - "--external-address"

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -77,11 +77,24 @@ services:
       - "1000"
       - "--pending-out-peers"
       - "1000"
-      - "--external-address"
-      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
-      - "--external-address"
-      - "/ip4/$EXTERNAL_IP/tcp/30533"
+## comment external addresses using IP format for now
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/tcp/30533"
 EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
 for (( i = 0; i < node_count; i++ )); do
   if [ "${current_node}" != "${i}" ]; then
     dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)


### PR DESCRIPTION
- bump to release nov-17
- bump to release nov-18
- bump to release nov-19
- use dns for `--external-address` parameter instead of IP addresses with bootstrap nodes.
- remove genensis farmer and change domain id to `1`