### PR TITLE
Rancher kubernetes clusters and node pools

### DIFF
--- a/rke/.gitattributes
+++ b/rke/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/rke/.gitignore
+++ b/rke/.gitignore
@@ -1,0 +1,26 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# terraform.tvars
+terraform.tfvars
+
+# known files created by terraform modules
+id_rsa*
+kube_config*
+
+# vagrant files
+.vagrant/
+vagrant/local_config.yaml
+
+# MacOS junk
+.DS_Store
+
+# Terraform plan files
+*.tfplan

--- a/rke/.gitignore
+++ b/rke/.gitignore
@@ -15,10 +15,6 @@ terraform.tfvars
 id_rsa*
 kube_config*
 
-# vagrant files
-.vagrant/
-vagrant/local_config.yaml
-
 # MacOS junk
 .DS_Store
 

--- a/rke/Makefile
+++ b/rke/Makefile
@@ -1,0 +1,27 @@
+PROVIDERS = rancher/rancher-common rancher/aws rancher/hcloud
+CLOUD_PROVIDERS = rancher/aws rancher/hcloud
+
+upgrade-targets = $(addprefix upgrade-, $(PROVIDERS))
+fmt-targets = $(addprefix fmt-, $(PROVIDERS))
+validate-targets = $(addprefix validate-, $(PROVIDERS))
+plan-targets = $(addprefix plan-, $(CLOUD_PROVIDERS))
+
+upgrade: $(upgrade-targets)
+$(upgrade-targets): upgrade-%: %
+	cd $< && terraform init -upgrade
+
+fmt: $(fmt-targets)
+$(fmt-targets): fmt-%: %
+	cd $< && terraform fmt
+
+validate: $(validate-targets)
+$(validate-targets): validate-%: %
+	cd $< && terraform validate
+
+plan: $(plan-targets)
+$(plan-targets): plan-%: %
+	cd $< && terraform plan
+
+.PHONY: clean
+clean:
+	rm */*/terraform.tfstate.backup

--- a/rke/README.md
+++ b/rke/README.md
@@ -1,0 +1,35 @@
+## Rancher Management Server
+
+### Cloud vendors
+
+- [**Amazon Web Services** (`aws`)](./rancher/aws)
+- [**Hetzner Cloud** (`hcloud`)](./rancher/hcloud)
+
+
+Each vendor module will install Rancher on a single-node K3s cluster, then will provision another single-node RKE2 workload cluster using a Custom cluster in Rancher.
+This setup provides easy access to the core Rancher functionality while establishing a foundation that can be easily expanded to a full HA Rancher server.
+
+## Requirements - Cloud
+
+- Terraform >=1.0.0
+- Credentials for the cloud provider
+
+### Using cloud modules
+
+To begin with any modules, perform the following steps:
+
+1. Clone or download this repository to a local folder
+2. Choose a cloud provider and navigate into the provider's folder
+3. Copy or rename `terraform.tfvars.example` to `terraform.tfvars` and fill in all required variables
+4. Run `terraform init`
+5. Run `terraform apply`
+
+When provisioning has finished, terraform will output the URL to connect to the Rancher server.
+Two sets of Kubernetes configurations will also be generated:
+- `kube_config_server.yaml` contains credentials to access the cluster supporting the Rancher server
+- `kube_config_workload.yaml` contains credentials to access the provisioned workload cluster
+
+
+### Destroy
+
+Run `terraform destroy -auto-approve` to remove all resources without prompting for confirmation.

--- a/rke/README.md
+++ b/rke/README.md
@@ -3,7 +3,7 @@
 ### Cloud vendors
 
 - [**Amazon Web Services** (`aws`)](./rancher/aws)
-- [**Hetzner Cloud** (`hcloud`)](./rancher/hcloud)
+- [**Hetzner Cloud** (`hcloud`)](./rancher/hetzner)
 
 
 Each vendor module will install Rancher on a single-node K3s cluster, then will provision another single-node RKE2 workload cluster using a Custom cluster in Rancher.

--- a/rke/README.md
+++ b/rke/README.md
@@ -5,7 +5,6 @@
 - [**Amazon Web Services** (`aws`)](./rancher/aws)
 - [**Hetzner Cloud** (`hcloud`)](./rancher/hetzner)
 
-
 Each vendor module will install Rancher on a single-node K3s cluster, then will provision another single-node RKE2 workload cluster using a Custom cluster in Rancher.
 This setup provides easy access to the core Rancher functionality while establishing a foundation that can be easily expanded to a full HA Rancher server.
 
@@ -22,13 +21,14 @@ To begin with any modules, perform the following steps:
 2. Choose a cloud provider and navigate into the provider's folder
 3. Copy or rename `terraform.tfvars.example` to `terraform.tfvars` and fill in all required variables
 4. Run `terraform init`
-5. Run `terraform apply`
+5. Run `terraform plan`
+6. Run `terraform apply`
 
 When provisioning has finished, terraform will output the URL to connect to the Rancher server.
 Two sets of Kubernetes configurations will also be generated:
+
 - `kube_config_server.yaml` contains credentials to access the cluster supporting the Rancher server
 - `kube_config_workload.yaml` contains credentials to access the provisioned workload cluster
-
 
 ### Destroy
 

--- a/rke/aws/data.tf
+++ b/rke/aws/data.tf
@@ -1,0 +1,29 @@
+# Data for AWS module
+
+# AWS data
+# ----------------------------------------------------------
+data "aws_ami" "ubuntu_amd64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}

--- a/rke/aws/data.tf
+++ b/rke/aws/data.tf
@@ -1,7 +1,4 @@
 # Data for AWS module
-
-# AWS data
-# ----------------------------------------------------------
 data "aws_ami" "ubuntu_amd64" {
   most_recent = true
 
@@ -25,5 +22,5 @@ data "aws_ami" "ubuntu_amd64" {
     values = ["ebs"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["099720109477"]
 }

--- a/rke/aws/files/userdata_node.template
+++ b/rke/aws/files/userdata_node.template
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+
+publicIP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/public-ipv4)
+privateIP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/local-ipv4)
+
+${register_command} --address $publicIP --internal-address $privateIP --etcd --controlplane --worker

--- a/rke/aws/infra.tf
+++ b/rke/aws/infra.tf
@@ -1,97 +1,5 @@
 # AWS infrastructure resources
 
-resource "tls_private_key" "global_key" {
-  algorithm = "RSA"
-  rsa_bits  = 2048
-}
-
-resource "local_sensitive_file" "ssh_private_key_pem" {
-  filename        = "${path.module}/id_rsa"
-  content         = tls_private_key.global_key.private_key_pem
-  file_permission = "0600"
-}
-
-resource "local_file" "ssh_public_key_openssh" {
-  filename = "${path.module}/id_rsa.pub"
-  content  = tls_private_key.global_key.public_key_openssh
-}
-
-# Temporary key pair used for SSH accesss
-resource "aws_key_pair" "subspace_key_pair" {
-  key_name_prefix = "${var.prefix}-rancher-"
-  public_key      = tls_private_key.global_key.public_key_openssh
-}
-
-resource "aws_vpc" "rancher_vpc" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_hostnames = true
-  tags = {
-    Name = "${var.prefix}-rancher-vpc"
-  }
-}
-
-resource "aws_internet_gateway" "rancher_gateway" {
-  vpc_id = aws_vpc.rancher_vpc.id
-
-  tags = {
-    Name = "${var.prefix}-rancher-gateway"
-  }
-}
-
-resource "aws_subnet" "rancher_subnet" {
-  vpc_id = aws_vpc.rancher_vpc.id
-
-  cidr_block        = "10.0.0.0/24"
-  availability_zone = var.aws_zone
-
-  tags = {
-    Name = "${var.prefix}-rancher-subnet"
-  }
-}
-
-resource "aws_route_table" "rancher_route_table" {
-  vpc_id = aws_vpc.rancher_vpc.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.rancher_gateway.id
-  }
-
-  tags = {
-    Name = "${var.prefix}-rancher-route-table"
-  }
-}
-
-resource "aws_route_table_association" "rancher_route_table_association" {
-  subnet_id      = aws_subnet.rancher_subnet.id
-  route_table_id = aws_route_table.rancher_route_table.id
-}
-
-# Security group to allow all traffic
-resource "aws_security_group" "rancher_sg_allowall" {
-  name        = "${var.prefix}-rancher-allowall"
-  description = "Rancher subspace - allow all traffic"
-  vpc_id      = aws_vpc.rancher_vpc.id
-
-  ingress {
-    from_port   = "0"
-    to_port     = "0"
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = "0"
-    to_port     = "0"
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Creator = "rancher-subspace"
-  }
-}
-
 # AWS EC2 instance for creating a single node RKE cluster and installing the Rancher server
 resource "aws_instance" "rancher_server" {
   depends_on = [
@@ -101,7 +9,7 @@ resource "aws_instance" "rancher_server" {
   instance_type = var.instance_type
 
   key_name                    = aws_key_pair.subspace_key_pair.key_name
-  vpc_security_group_ids      = [aws_security_group.rancher_sg_allowall.id]
+  vpc_security_group_ids      = [aws_security_group.rancher_sg_allow.id]
   subnet_id                   = aws_subnet.rancher_subnet.id
   associate_public_ip_address = true
 
@@ -126,7 +34,7 @@ resource "aws_instance" "rancher_server" {
 
   tags = {
     Name    = "${var.prefix}-rancher-server"
-    Creator = "rancher-subspace"
+    Creator = "rancher-${var.prefix}"
   }
 }
 
@@ -149,7 +57,7 @@ module "rancher_common" {
   admin_password = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version
-  workload_cluster_name       = "subspace_workload"
+  workload_cluster_name       = "${var.prefix}_workload"
 }
 
 # AWS EC2 instance for creating a single node workload cluster
@@ -157,11 +65,11 @@ resource "aws_instance" "subspace_workload" {
   depends_on = [
     aws_route_table_association.rancher_route_table_association
   ]
-  ami           = data.aws_ami.ubuntu_x86.id
+  ami           = data.aws_ami.ubuntu_amd64.id
   instance_type = var.instance_type
 
   key_name                    = aws_key_pair.subspace_key_pair.key_name
-  vpc_security_group_ids      = [aws_security_group.rancher_sg_allowall.id]
+  vpc_security_group_ids      = [aws_security_group.rancher_sg_allow.id]
   subnet_id                   = aws_subnet.rancher_subnet.id
   associate_public_ip_address = true
 
@@ -192,7 +100,7 @@ resource "aws_instance" "subspace_workload" {
   }
 
   tags = {
-    Name    = "${var.prefix}-subspace-node-pool"
-    Creator = "rancher-subspace"
+    Name    = "${var.prefix}-worker-node"
+    Creator = "${var.prefix}"
   }
 }

--- a/rke/aws/infra.tf
+++ b/rke/aws/infra.tf
@@ -1,0 +1,198 @@
+# AWS infrastructure resources
+
+resource "tls_private_key" "global_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "local_sensitive_file" "ssh_private_key_pem" {
+  filename        = "${path.module}/id_rsa"
+  content         = tls_private_key.global_key.private_key_pem
+  file_permission = "0600"
+}
+
+resource "local_file" "ssh_public_key_openssh" {
+  filename = "${path.module}/id_rsa.pub"
+  content  = tls_private_key.global_key.public_key_openssh
+}
+
+# Temporary key pair used for SSH accesss
+resource "aws_key_pair" "subspace_key_pair" {
+  key_name_prefix = "${var.prefix}-rancher-"
+  public_key      = tls_private_key.global_key.public_key_openssh
+}
+
+resource "aws_vpc" "rancher_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.prefix}-rancher-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "rancher_gateway" {
+  vpc_id = aws_vpc.rancher_vpc.id
+
+  tags = {
+    Name = "${var.prefix}-rancher-gateway"
+  }
+}
+
+resource "aws_subnet" "rancher_subnet" {
+  vpc_id = aws_vpc.rancher_vpc.id
+
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = var.aws_zone
+
+  tags = {
+    Name = "${var.prefix}-rancher-subnet"
+  }
+}
+
+resource "aws_route_table" "rancher_route_table" {
+  vpc_id = aws_vpc.rancher_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.rancher_gateway.id
+  }
+
+  tags = {
+    Name = "${var.prefix}-rancher-route-table"
+  }
+}
+
+resource "aws_route_table_association" "rancher_route_table_association" {
+  subnet_id      = aws_subnet.rancher_subnet.id
+  route_table_id = aws_route_table.rancher_route_table.id
+}
+
+# Security group to allow all traffic
+resource "aws_security_group" "rancher_sg_allowall" {
+  name        = "${var.prefix}-rancher-allowall"
+  description = "Rancher subspace - allow all traffic"
+  vpc_id      = aws_vpc.rancher_vpc.id
+
+  ingress {
+    from_port   = "0"
+    to_port     = "0"
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = "0"
+    to_port     = "0"
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Creator = "rancher-subspace"
+  }
+}
+
+# AWS EC2 instance for creating a single node RKE cluster and installing the Rancher server
+resource "aws_instance" "rancher_server" {
+  depends_on = [
+    aws_route_table_association.rancher_route_table_association
+  ]
+  ami           = data.aws_ami.ubuntu_amd64.id
+  instance_type = var.instance_type
+
+  key_name                    = aws_key_pair.subspace_key_pair.key_name
+  vpc_security_group_ids      = [aws_security_group.rancher_sg_allowall.id]
+  subnet_id                   = aws_subnet.rancher_subnet.id
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_size = 40
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.public_ip
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+
+  tags = {
+    Name    = "${var.prefix}-rancher-server"
+    Creator = "rancher-subspace"
+  }
+}
+
+# Rancher resources
+module "rancher_common" {
+  source = "../rancher-common"
+
+  node_public_ip             = aws_instance.rancher_server.public_ip
+  node_internal_ip           = aws_instance.rancher_server.private_ip
+  node_username              = local.node_username
+  ssh_private_key_pem        = tls_private_key.global_key.private_key_pem
+  rancher_kubernetes_version = var.rancher_kubernetes_version
+
+  cert_manager_version    = var.cert_manager_version
+  rancher_version         = var.rancher_version
+  rancher_helm_repository = var.rancher_helm_repository
+
+  rancher_server_dns = join(".", ["rancher", aws_instance.rancher_server.public_ip, "sslip.io"])
+
+  admin_password = var.rancher_server_admin_password
+
+  workload_kubernetes_version = var.workload_kubernetes_version
+  workload_cluster_name       = "subspace_workload"
+}
+
+# AWS EC2 instance for creating a single node workload cluster
+resource "aws_instance" "subspace_workload" {
+  depends_on = [
+    aws_route_table_association.rancher_route_table_association
+  ]
+  ami           = data.aws_ami.ubuntu_x86.id
+  instance_type = var.instance_type
+
+  key_name                    = aws_key_pair.subspace_key_pair.key_name
+  vpc_security_group_ids      = [aws_security_group.rancher_sg_allowall.id]
+  subnet_id                   = aws_subnet.rancher_subnet.id
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_size = 40
+  }
+
+  user_data = templatefile(
+    "${path.module}/files/userdata_node.template",
+    {
+      register_command = module.rancher_common.custom_cluster_command
+    }
+  )
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.public_ip
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+
+  tags = {
+    Name    = "${var.prefix}-subspace-node-pool"
+    Creator = "rancher-subspace"
+  }
+}

--- a/rke/aws/network.tf
+++ b/rke/aws/network.tf
@@ -1,0 +1,44 @@
+resource "aws_vpc" "rancher_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.prefix}-rancher-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "rancher_gateway" {
+  vpc_id = aws_vpc.rancher_vpc.id
+
+  tags = {
+    Name = "${var.prefix}-rancher-gateway"
+  }
+}
+
+resource "aws_subnet" "rancher_subnet" {
+  vpc_id = aws_vpc.rancher_vpc.id
+
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = var.aws_zone
+
+  tags = {
+    Name = "${var.prefix}-rancher-subnet"
+  }
+}
+
+resource "aws_route_table" "rancher_route_table" {
+  vpc_id = aws_vpc.rancher_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.rancher_gateway.id
+  }
+
+  tags = {
+    Name = "${var.prefix}-rancher-route-table"
+  }
+}
+
+resource "aws_route_table_association" "rancher_route_table_association" {
+  subnet_id      = aws_subnet.rancher_subnet.id
+  route_table_id = aws_route_table.rancher_route_table.id
+}

--- a/rke/aws/outputs.tf
+++ b/rke/aws/outputs.tf
@@ -1,0 +1,11 @@
+output "rancher_server_url" {
+  value = module.rancher_common.rancher_url
+}
+
+output "rancher_node_ip" {
+  value = aws_instance.rancher_server.public_ip
+}
+
+output "workload_node_ip" {
+  value = aws_instance.subspace_workload.public_ip
+}

--- a/rke/aws/provider.tf
+++ b/rke/aws/provider.tf
@@ -13,7 +13,7 @@ terraform {
       version = ">=3.4.0"
     }
   }
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.4.2"
 }
 
 provider "aws" {

--- a/rke/aws/provider.tf
+++ b/rke/aws/provider.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.55.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.2.3"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">=3.4.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  token      = var.aws_session_token
+  region     = var.aws_region
+}
+
+provider "random" {}

--- a/rke/aws/security_group_elb.tf
+++ b/rke/aws/security_group_elb.tf
@@ -1,0 +1,39 @@
+resource "aws_security_group" "ingress_elb" {
+  name        = "${var.prefix}-ingress-elb"
+  description = "Security group for the ingress ELB"
+  vpc_id      = aws_vpc.rancher_vpc.id
+  tags = {
+    Name    = "rancher-elb-sg"
+    Creator = "${var.prefix}"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_elb_egress" {
+  description       = "Allow all egress traffic"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007
+  security_group_id = aws_security_group.ingress_elb.id
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ingress_elb_port_http" {
+  description       = "Allow HTTP traffic from everywhere"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006
+  security_group_id = aws_security_group.ingress_elb.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "ingress_elb_port_https" {
+  description       = "Allow HTTPS traffic from everywhere"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006
+  security_group_id = aws_security_group.ingress_elb.id
+  type              = "ingress"
+}

--- a/rke/aws/security_group_nodes.tf
+++ b/rke/aws/security_group_nodes.tf
@@ -1,0 +1,69 @@
+resource "aws_security_group" "rancher_sg_allow" {
+  name        = "${var.prefix}-nodes-sg"
+  description = "Security group for RKE nodes"
+  vpc_id      = aws_vpc.rancher_vpc.id
+  tags = {
+    Name    = "rancher-sg"
+    Creator = "${var.prefix}"
+  }
+}
+
+resource "aws_security_group_rule" "nodes_egress" {
+  description       = "Allow all egress traffic"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.rancher_sg_allow.id
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "nodes_ingress_self" {
+  description       = "Allow all intra-security-group traffic"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  self              = true
+  security_group_id = aws_security_group.rancher_sg_allow.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "nodes_ingress_ssh" {
+  description       = "Allow all SSH traffic"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.rancher_sg_allow.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "nodes_ingress_k8s" {
+  description       = "Allow all k8s API traffic"
+  from_port         = 6443
+  to_port           = 6443
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006
+  security_group_id = aws_security_group.rancher_sg_allow.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "nodes_ingress_elb_80" {
+  description              = "Allow HTTP traffic from the ELB"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "TCP"
+  source_security_group_id = aws_security_group.ingress_elb.id
+  security_group_id        = aws_security_group.rancher_sg_allow.id
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "nodes_ingress_elb_443" {
+  description              = "Allow HTTPS traffic from the ELB"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "TCP"
+  source_security_group_id = aws_security_group.ingress_elb.id
+  security_group_id        = aws_security_group.rancher_sg_allow.id
+  type                     = "ingress"
+}

--- a/rke/aws/ssh.tf
+++ b/rke/aws/ssh.tf
@@ -1,0 +1,21 @@
+resource "tls_private_key" "global_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_sensitive_file" "ssh_private_key_pem" {
+  filename        = "${path.module}/id_rsa"
+  content         = tls_private_key.global_key.private_key_pem
+  file_permission = "0600"
+}
+
+resource "local_file" "ssh_public_key_openssh" {
+  filename = "${path.module}/id_rsa.pub"
+  content  = tls_private_key.global_key.public_key_openssh
+}
+
+# Temporary key pair used for SSH accesss
+resource "aws_key_pair" "subspace_key_pair" {
+  key_name_prefix = "${var.prefix}-rancher-"
+  public_key      = tls_private_key.global_key.public_key_openssh
+}

--- a/rke/aws/variables.tf
+++ b/rke/aws/variables.tf
@@ -1,14 +1,8 @@
 # Variables for AWS infrastructure module
-
-// TODO - use null defaults
-
-# Required
 variable "aws_access_key" {
   type        = string
   description = "AWS access key used to create infrastructure"
 }
-
-# Required
 variable "aws_secret_key" {
   type        = string
   description = "AWS secret key used to create AWS infrastructure"
@@ -41,30 +35,30 @@ variable "prefix" {
 variable "instance_type" {
   type        = string
   description = "Instance type used for all EC2 instances"
-  default     = "t3a.medium"
+  default     = "m6i.xlarge"
 }
 
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.24.13+k3s1"
+  default     = "v1.26.4+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.24.13+rke2r1"
+  default     = "v1.27.1+rke2r1"
 }
 
 variable "cert_manager_version" {
   type        = string
-  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
-  default     = "1.10.0"
+  description = "Version of cert-manager to install alongside Rancher"
+  default     = "1.11.0"
 }
 
 variable "rancher_version" {
   type        = string
-  description = "Rancher server version (format: v0.0.0)"
+  description = "Rancher server version"
   default     = "2.7.3"
 }
 
@@ -73,8 +67,6 @@ variable "rancher_helm_repository" {
   description = "The helm repository, where the Rancher helm chart is installed from"
   default     = "https://releases.rancher.com/server-charts/latest"
 }
-
-# Required
 variable "rancher_server_admin_password" {
   type        = string
   description = "Admin password to use for Rancher server bootstrap, min. 12 characters"

--- a/rke/aws/variables.tf
+++ b/rke/aws/variables.tf
@@ -1,0 +1,86 @@
+# Variables for AWS infrastructure module
+
+// TODO - use null defaults
+
+# Required
+variable "aws_access_key" {
+  type        = string
+  description = "AWS access key used to create infrastructure"
+}
+
+# Required
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS secret key used to create AWS infrastructure"
+}
+
+variable "aws_session_token" {
+  type        = string
+  description = "AWS session token used to create AWS infrastructure"
+  default     = ""
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region used for all resources"
+  default     = "us-east-2"
+}
+
+variable "aws_zone" {
+  type        = string
+  description = "AWS zone used for all resources"
+  default     = "us-east-2a"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Prefix added to names of all resources"
+  default     = "subspace"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Instance type used for all EC2 instances"
+  default     = "t3a.medium"
+}
+
+variable "rancher_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for Rancher server cluster"
+  default     = "v1.24.13+k3s1"
+}
+
+variable "workload_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for managed workload cluster"
+  default     = "v1.24.13+rke2r1"
+}
+
+variable "cert_manager_version" {
+  type        = string
+  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
+  default     = "1.10.0"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Rancher server version (format: v0.0.0)"
+  default     = "2.7.3"
+}
+
+variable "rancher_helm_repository" {
+  type        = string
+  description = "The helm repository, where the Rancher helm chart is installed from"
+  default     = "https://releases.rancher.com/server-charts/latest"
+}
+
+# Required
+variable "rancher_server_admin_password" {
+  type        = string
+  description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
+}
+
+# Local variables used to reduce repetition
+locals {
+  node_username = "ubuntu"
+}

--- a/rke/aws/variables.tf
+++ b/rke/aws/variables.tf
@@ -41,25 +41,25 @@ variable "instance_type" {
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.26.4+k3s1"
+  default     = "v1.29.0+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.27.1+rke2r1"
+  default     = "v1.28.4+rke2r1"
 }
 
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-manager to install alongside Rancher"
-  default     = "1.11.0"
+  default     = "1.12.7"
 }
 
 variable "rancher_version" {
   type        = string
   description = "Rancher server version"
-  default     = "2.7.3"
+  default     = "2.8.0"
 }
 
 variable "rancher_helm_repository" {

--- a/rke/hetzner/files/userdata_node.template
+++ b/rke/hetzner/files/userdata_node.template
@@ -1,0 +1,3 @@
+#!/bin/bash -x
+
+${register_command} --etcd --controlplane --worker

--- a/rke/hetzner/infra.tf
+++ b/rke/hetzner/infra.tf
@@ -1,0 +1,128 @@
+# HCloud infrastructure resources
+
+resource "tls_private_key" "global_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "local_sensitive_file" "ssh_private_key_pem" {
+  filename        = "${path.module}/id_rsa"
+  content         = tls_private_key.global_key.private_key_pem
+  file_permission = "0600"
+}
+
+resource "local_file" "ssh_public_key_openssh" {
+  filename = "${path.module}/id_rsa.pub"
+  content  = tls_private_key.global_key.public_key_openssh
+}
+
+resource "hcloud_network" "private" {
+  name     = "${var.prefix}-private-network"
+  ip_range = var.network_cidr
+}
+
+resource "hcloud_network_subnet" "private" {
+  type         = "cloud"
+  network_id   = hcloud_network.private.id
+  network_zone = var.network_zone
+  ip_range     = var.network_ip_range
+}
+
+# Temporary key pair used for SSH accesss
+resource "hcloud_ssh_key" "subspace_ssh_key" {
+  name       = "${var.prefix}-instance-ssh-key"
+  public_key = tls_private_key.global_key.public_key_openssh
+}
+
+# HCloud Instance for creating a single node RKE cluster and installing the Rancher server
+resource "hcloud_server" "rancher_server" {
+  name        = "${var.prefix}-rancher-server"
+  image       = "ubuntu-20.04"
+  server_type = var.instance_type
+  location    = var.hcloud_location
+  ssh_keys    = [hcloud_ssh_key.subspace_ssh_key.id]
+
+  network {
+    network_id = hcloud_network.private.id
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.ipv4_address
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+
+  depends_on = [
+    hcloud_network_subnet.private
+  ]
+}
+
+# Rancher resources
+module "rancher_common" {
+  source = "../rancher-common"
+
+  node_public_ip             = hcloud_server.rancher_server.ipv4_address
+  node_internal_ip           = one(hcloud_server.rancher_server.network[*]).ip
+  node_username              = local.node_username
+  ssh_private_key_pem        = tls_private_key.global_key.private_key_pem
+  rancher_kubernetes_version = var.rancher_kubernetes_version
+
+  cert_manager_version    = var.cert_manager_version
+  rancher_version         = var.rancher_version
+  rancher_helm_repository = var.rancher_helm_repository
+
+  rancher_server_dns = join(".", ["rancher", hcloud_server.rancher_server.ipv4_address, "sslip.io"])
+  admin_password     = var.rancher_server_admin_password
+
+  workload_kubernetes_version = var.workload_kubernetes_version
+  workload_cluster_name       = "subspace-hcloud-custom"
+}
+
+# HCloud instance for creating a single node workload cluster
+resource "hcloud_server" "subspace_node" {
+  name        = "${var.prefix}-worker"
+  image       = "ubuntu-20.04"
+  server_type = var.instance_type
+  location    = var.hcloud_location
+  ssh_keys    = [hcloud_ssh_key.subspace_ssh_key.id]
+
+  network {
+    network_id = hcloud_network.private.id
+  }
+
+  user_data = templatefile(
+    "${path.module}/files/userdata_node.template",
+    {
+      username         = local.node_username
+      register_command = module.rancher_common.custom_cluster_command
+    }
+  )
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.ipv4_address
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+
+  depends_on = [
+    hcloud_network_subnet.private
+  ]
+}

--- a/rke/hetzner/infra.tf
+++ b/rke/hetzner/infra.tf
@@ -84,7 +84,7 @@ module "rancher_common" {
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version
-  workload_cluster_name       = "subspace-hcloud-custom"
+  workload_cluster_name       = "${var.prefix}-hcloud-custom"
 }
 
 # HCloud instance for creating a single node workload cluster

--- a/rke/hetzner/output.tf
+++ b/rke/hetzner/output.tf
@@ -1,0 +1,12 @@
+
+output "rancher_server_url" {
+  value = module.rancher_common.rancher_url
+}
+
+output "rancher_node_ip" {
+  value = hcloud_server.rancher_server.ipv4_address
+}
+
+output "workload_node_ip" {
+  value = hcloud_server.subspace_node.ipv4_address
+}

--- a/rke/hetzner/provider.tf
+++ b/rke/hetzner/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.33.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.2.3"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.4.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}

--- a/rke/hetzner/variables.tf
+++ b/rke/hetzner/variables.tf
@@ -44,25 +44,25 @@ variable "instance_type" {
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.26.4+k3s1"
+  default     = "v1.29.0+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.27.1+rke2r1"
+  default     = "v1.28.4+rke2r1"
 }
 
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
-  default     = "1.11.0"
+  default     = "1.12.7"
 }
 
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "2.7.3"
+  default     = "2.8.0"
 }
 
 variable "rancher_helm_repository" {

--- a/rke/hetzner/variables.tf
+++ b/rke/hetzner/variables.tf
@@ -44,19 +44,19 @@ variable "instance_type" {
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.24.13+k3s1"
+  default     = "v1.26.4+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.24.13+rke2r1"
+  default     = "v1.27.1+rke2r1"
 }
 
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
-  default     = "1.10.0"
+  default     = "1.11.0"
 }
 
 variable "rancher_version" {

--- a/rke/hetzner/variables.tf
+++ b/rke/hetzner/variables.tf
@@ -1,0 +1,82 @@
+# Variables for Hetzner Cloud infrastructure module
+
+variable "hcloud_token" {
+  type        = string
+  description = "Hetzner Cloud API token used to create infrastructure"
+}
+
+variable "hcloud_location" {
+  type        = string
+  description = "Hetzner location used for all resources"
+  default     = "fsn1"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Prefix added to names of all resources"
+  default     = "subspace"
+}
+
+variable "network_cidr" {
+  type        = string
+  description = "Network to create for private communication"
+  default     = "10.0.0.0/8"
+}
+
+variable "network_ip_range" {
+  type        = string
+  description = "Subnet to create for private communication. Must be part of the CIDR defined in `network_cidr`."
+  default     = "10.0.1.0/24"
+}
+
+variable "network_zone" {
+  type        = string
+  description = "Zone to create the network in"
+  default     = "eu-central"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Type of instance to be used for all instances"
+  default     = "cx21"
+}
+
+variable "rancher_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for Rancher server cluster"
+  default     = "v1.24.13+k3s1"
+}
+
+variable "workload_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for managed workload cluster"
+  default     = "v1.24.13+rke2r1"
+}
+
+variable "cert_manager_version" {
+  type        = string
+  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
+  default     = "1.10.0"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Rancher server version (format: v0.0.0)"
+  default     = "2.7.3"
+}
+
+variable "rancher_helm_repository" {
+  type        = string
+  description = "The helm repository, where the Rancher helm chart is installed from"
+  default     = "https://releases.rancher.com/server-charts/latest"
+}
+
+variable "rancher_server_admin_password" {
+  type        = string
+  description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
+}
+
+# Local variables used to reduce repetition
+locals {
+  node_username = "root"
+}

--- a/rke/rancher-common/data.tf
+++ b/rke/rancher-common/data.tf
@@ -1,0 +1,14 @@
+# Data for rancher common module
+
+# Kubernetes data
+# ----------------------------------------------------------
+
+# # Rancher certificates
+# data "kubernetes_secret" "rancher_cert" {
+#   depends_on = [helm_release.rancher_server]
+
+#   metadata {
+#     name      = "tls-rancher-ingress"
+#     namespace = "cattle-system"
+#   }
+# }

--- a/rke/rancher-common/data.tf
+++ b/rke/rancher-common/data.tf
@@ -1,14 +1,11 @@
 # Data for rancher common module
 
-# Kubernetes data
-# ----------------------------------------------------------
+# Rancher certificates
+data "kubernetes_secret" "rancher_cert" {
+  depends_on = [helm_release.rancher_server]
 
-# # Rancher certificates
-# data "kubernetes_secret" "rancher_cert" {
-#   depends_on = [helm_release.rancher_server]
-
-#   metadata {
-#     name      = "tls-rancher-ingress"
-#     namespace = "cattle-system"
-#   }
-# }
+  metadata {
+    name      = "tls-rancher-ingress"
+    namespace = "cattle-system"
+  }
+}

--- a/rke/rancher-common/helm.tf
+++ b/rke/rancher-common/helm.tf
@@ -1,0 +1,43 @@
+# Helm resources
+
+# Install cert-manager helm chart
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  chart            = "https://charts.jetstack.io/charts/cert-manager-v${var.cert_manager_version}.tgz"
+  namespace        = "cert-manager"
+  create_namespace = true
+  wait             = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}
+
+# Install Rancher helm chart
+resource "helm_release" "rancher_server" {
+  depends_on = [
+    helm_release.cert_manager,
+  ]
+
+  name             = "rancher"
+  chart            = "${var.rancher_helm_repository}/rancher-${var.rancher_version}.tgz"
+  namespace        = "cattle-system"
+  create_namespace = true
+  wait             = true
+
+  set {
+    name  = "hostname"
+    value = var.rancher_server_dns
+  }
+
+  set {
+    name  = "replicas"
+    value = "1"
+  }
+
+  set {
+    name  = "bootstrapPassword"
+    value = "admin" # TODO: change this once the terraform provider has been updated with the new pw bootstrap logic
+  }
+}

--- a/rke/rancher-common/k3s.tf
+++ b/rke/rancher-common/k3s.tf
@@ -1,0 +1,22 @@
+# K3s cluster for Rancher
+
+resource "ssh_resource" "install_k3s" {
+  host = var.node_public_ip
+  commands = [
+    "sudo bash -c 'curl https://get.k3s.io | INSTALL_K3S_EXEC=\"server --node-external-ip ${var.node_public_ip} --node-ip ${var.node_internal_ip}\" INSTALL_K3S_VERSION=${var.rancher_kubernetes_version} sh -'"
+  ]
+  user        = var.node_username
+  private_key = var.ssh_private_key_pem
+}
+
+resource "ssh_resource" "retrieve_config" {
+  depends_on = [
+    ssh_resource.install_k3s
+  ]
+  host = var.node_public_ip
+  commands = [
+    "sudo sed \"s/127.0.0.1/${var.node_public_ip}/g\" /etc/rancher/k3s/k3s.yaml"
+  ]
+  user        = var.node_username
+  private_key = var.ssh_private_key_pem
+}

--- a/rke/rancher-common/local.tf
+++ b/rke/rancher-common/local.tf
@@ -1,0 +1,12 @@
+# Local resources
+
+# Save kubeconfig file for interacting with the RKE cluster on your local machine
+resource "local_file" "kube_config_server_yaml" {
+  filename = format("%s/%s", path.root, "kube_config_server.yaml")
+  content  = ssh_resource.retrieve_config.result
+}
+
+resource "local_file" "kube_config_workload_yaml" {
+  filename = format("%s/%s", path.root, "kube_config_workload.yaml")
+  content  = rancher2_cluster_v2.subspace_workload.kube_config
+}

--- a/rke/rancher-common/output.tf
+++ b/rke/rancher-common/output.tf
@@ -1,0 +1,21 @@
+# Outputs
+
+output "rancher_url" {
+  value = "https://${var.rancher_server_dns}"
+}
+
+output "custom_cluster_command" {
+  value       = rancher2_cluster_v2.subspace_workload.cluster_registration_token.0.insecure_node_command
+  description = "Docker command used to add a node to the subspace cluster"
+}
+
+output "rancher_admin_password" {
+  description = "Password for Rancher 'admin' user"
+  value       = random_password.rancher_admin_pasword.result
+  sensitive   = true
+}
+
+output "rancher_admin_token" {
+  description = "API Token for Rancher 'admin' user"
+  value       = rancher2_bootstrap.admin.token
+}

--- a/rke/rancher-common/provider.tf
+++ b/rke/rancher-common/provider.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.5.1"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.2.3"
+    }
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = "1.24.0"
+    }
+    ssh = {
+      source  = "loafoe/ssh"
+      version = "1.2.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = local_file.kube_config_server_yaml.filename
+  }
+}
+
+# Rancher2 bootstrapping provider
+provider "rancher2" {
+  alias = "bootstrap"
+
+  api_url  = "https://${var.rancher_server_dns}"
+  insecure = true
+  # ca_certs  = data.kubernetes_secret.rancher_cert.data["ca.crt"]
+  bootstrap = true
+}
+
+# Rancher2 administration provider
+provider "rancher2" {
+  alias = "admin"
+
+  api_url  = "https://${var.rancher_server_dns}"
+  insecure = true
+  # ca_certs  = data.kubernetes_secret.rancher_cert.data["ca.crt"]
+  token_key = rancher2_bootstrap.admin.token
+  timeout   = "300s"
+}

--- a/rke/rancher-common/rancher.tf
+++ b/rke/rancher-common/rancher.tf
@@ -1,0 +1,34 @@
+# Rancher resources
+
+resource "random_password" "rancher_admin_pasword" {
+  length           = 16
+  upper            = true
+  min_upper        = 1
+  lower            = true
+  min_lower        = 1
+  numeric          = true
+  min_numeric      = 1
+  special          = true
+  min_special      = 1
+  override_special = "_%@"
+}
+
+# Initialize Rancher server
+resource "rancher2_bootstrap" "admin" {
+  depends_on = [
+    helm_release.rancher_server
+  ]
+
+  provider = rancher2.bootstrap
+
+  password  = random_password.rancher_admin_pasword.result
+  telemetry = true
+}
+
+# Create custom managed cluster for subspace
+resource "rancher2_cluster_v2" "subspace_workload" {
+  provider = rancher2.admin
+
+  name               = var.workload_cluster_name
+  kubernetes_version = var.workload_kubernetes_version
+}

--- a/rke/rancher-common/terraform.tfvars.example
+++ b/rke/rancher-common/terraform.tfvars.example
@@ -1,0 +1,36 @@
+
+# Admin password to use for Rancher server bootstrap, min. 12 characters
+admin_password = ""
+
+# Public IP of compute node for Rancher cluster
+node_public_ip = ""
+
+# Username used for SSH access to the Rancher server cluster node
+node_username = ""
+
+# DNS host name of the Rancher server
+rancher_server_dns = ""
+
+# Private key used for SSH access to the Rancher server cluster node
+ssh_private_key_pem = ""
+
+# Name for created custom workload cluster
+workload_cluster_name = ""
+
+# Version of cert-manager to install alongside Rancher (format: 0.0.0)
+cert_manager_version = "1.10.0"
+
+# Internal IP of compute node for Rancher cluster
+node_internal_ip = ""
+
+# The helm repository, where the Rancher helm chart is installed from
+rancher_helm_repository = "https://releases.rancher.com/server-charts/latest"
+
+# Kubernetes version to use for Rancher server cluster
+rancher_kubernetes_version = "v1.24.13+k3s1"
+
+# Rancher server version (format v0.0.0)
+rancher_version = "2.7.3"
+
+# Kubernetes version to use for managed workload cluster
+workload_kubernetes_version = "v1.24.13+rke2r1"

--- a/rke/rancher-common/terraform.tfvars.example
+++ b/rke/rancher-common/terraform.tfvars.example
@@ -18,7 +18,7 @@ ssh_private_key_pem = ""
 workload_cluster_name = ""
 
 # Version of cert-manager to install alongside Rancher (format: 0.0.0)
-cert_manager_version = "1.10.0"
+cert_manager_version = "1.11.0"
 
 # Internal IP of compute node for Rancher cluster
 node_internal_ip = ""
@@ -27,10 +27,10 @@ node_internal_ip = ""
 rancher_helm_repository = "https://releases.rancher.com/server-charts/latest"
 
 # Kubernetes version to use for Rancher server cluster
-rancher_kubernetes_version = "v1.24.13+k3s1"
+rancher_kubernetes_version = "v1.26.4+k3s1"
 
 # Rancher server version (format v0.0.0)
 rancher_version = "2.7.3"
 
 # Kubernetes version to use for managed workload cluster
-workload_kubernetes_version = "v1.24.13+rke2r1"
+workload_kubernetes_version = "v1.27.1+rke2r1"

--- a/rke/rancher-common/variables.tf
+++ b/rke/rancher-common/variables.tf
@@ -1,0 +1,73 @@
+# Variables for rancher common module
+
+# Required
+variable "node_public_ip" {
+  type        = string
+  description = "Public IP of compute node for Rancher cluster"
+}
+
+variable "node_internal_ip" {
+  type        = string
+  description = "Internal IP of compute node for Rancher cluster"
+  default     = ""
+}
+
+# Required
+variable "node_username" {
+  type        = string
+  description = "Username used for SSH access to the Rancher server cluster node"
+}
+
+# Required
+variable "ssh_private_key_pem" {
+  type        = string
+  description = "Private key used for SSH access to the Rancher server cluster node"
+}
+
+variable "rancher_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for Rancher server cluster"
+  default     = "v1.24.13+k3s1"
+}
+
+variable "cert_manager_version" {
+  type        = string
+  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
+  default     = "1.10.0"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Rancher server version (format v0.0.0)"
+  default     = "2.7.3"
+}
+
+# Required
+variable "rancher_server_dns" {
+  type        = string
+  description = "DNS host name of the Rancher server"
+}
+
+# Required
+variable "admin_password" {
+  type        = string
+  description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
+}
+
+variable "workload_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for managed workload cluster"
+  default     = "v1.24.13+rke2r1"
+}
+
+# Required
+variable "workload_cluster_name" {
+  type        = string
+  description = "Name for created custom workload cluster"
+}
+
+variable "rancher_helm_repository" {
+  type        = string
+  description = "The helm repository, where the Rancher helm chart is installed from"
+  default     = "https://releases.rancher.com/server-charts/latest"
+}

--- a/rke/rancher-common/variables.tf
+++ b/rke/rancher-common/variables.tf
@@ -1,6 +1,4 @@
 # Variables for rancher common module
-
-# Required
 variable "node_public_ip" {
   type        = string
   description = "Public IP of compute node for Rancher cluster"
@@ -11,14 +9,10 @@ variable "node_internal_ip" {
   description = "Internal IP of compute node for Rancher cluster"
   default     = ""
 }
-
-# Required
 variable "node_username" {
   type        = string
   description = "Username used for SSH access to the Rancher server cluster node"
 }
-
-# Required
 variable "ssh_private_key_pem" {
   type        = string
   description = "Private key used for SSH access to the Rancher server cluster node"
@@ -27,40 +21,34 @@ variable "ssh_private_key_pem" {
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.24.13+k3s1"
-}
-
-variable "cert_manager_version" {
-  type        = string
-  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
-  default     = "1.10.0"
-}
-
-variable "rancher_version" {
-  type        = string
-  description = "Rancher server version (format v0.0.0)"
-  default     = "2.7.3"
-}
-
-# Required
-variable "rancher_server_dns" {
-  type        = string
-  description = "DNS host name of the Rancher server"
-}
-
-# Required
-variable "admin_password" {
-  type        = string
-  description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
+  default     = "v1.26.4+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.24.13+rke2r1"
+  default     = "v1.27.1+rke2r1"
 }
 
-# Required
+variable "cert_manager_version" {
+  type        = string
+  description = "Version of cert-manager to install alongside Rancher"
+  default     = "1.11.0"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Rancher server version"
+  default     = "2.7.3"
+}
+variable "rancher_server_dns" {
+  type        = string
+  description = "DNS host name of the Rancher server"
+}
+variable "admin_password" {
+  type        = string
+  description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
+}
 variable "workload_cluster_name" {
   type        = string
   description = "Name for created custom workload cluster"

--- a/rke/rancher-common/variables.tf
+++ b/rke/rancher-common/variables.tf
@@ -21,25 +21,25 @@ variable "ssh_private_key_pem" {
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.26.4+k3s1"
+  default     = "v1.29.0+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.27.1+rke2r1"
+  default     = "v1.28.4+rke2r1"
 }
 
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-manager to install alongside Rancher"
-  default     = "1.11.0"
+  default     = "1.12.7"
 }
 
 variable "rancher_version" {
   type        = string
   description = "Rancher server version"
-  default     = "2.7.3"
+  default     = "2.8.0"
 }
 variable "rancher_server_dns" {
   type        = string


### PR DESCRIPTION
The PR adds terraform declarations for RKE (rancher) self managed kubernetes clusters on both AWS and Hetzner cloud as infrastructure providers.

Features include: 
- Ubuntu OS Image for nodes
- RKE2 Scalable clusters for workloads
- K3s for rancher cluster

Cilium will be added as the CNI for networking into the cluster (https://docs.cilium.io/en/stable/installation/k8s-install-rancher-existing-nodes/)