### PR TITLE
update parameters for consensus and domain nodes

### DIFF
--- a/aws/devnet/main.tf
+++ b/aws/devnet/main.tf
@@ -32,7 +32,7 @@ module "devnet" {
     genesis-hash       = ""
     dsn-listen-port    = 30533
     node-dsn-port      = 30433
-    operator-port      = 40333
+    operator-port      = 30334
     disk-volume-size   = var.disk_volume_size
     disk-volume-type   = var.disk_volume_type
   }

--- a/aws/gemini-3f/main.tf
+++ b/aws/gemini-3f/main.tf
@@ -1,7 +1,7 @@
 module "gemini-3f" {
-  source          = "../network-primitives"
-  path_to_scripts = "../network-primitives/scripts"
-  path_to_configs = "../network-primitives/configs"
+  source          = "../network-primitives-archive"
+  path_to_scripts = "../network-primitives-archive/scripts"
+  path_to_configs = "../network-primitives-archive/configs"
   network_name    = "gemini-3f"
   bootstrap-node-config = {
     instance-type      = var.instance_type["bootstrap"]

--- a/aws/gemini-3g/main.tf
+++ b/aws/gemini-3g/main.tf
@@ -1,7 +1,7 @@
 module "gemini-3g" {
-  source          = "../network-primitives"
-  path_to_scripts = "../network-primitives/scripts"
-  path_to_configs = "../network-primitives/configs"
+  source          = "../network-primitives-archive"
+  path_to_scripts = "../network-primitives-archive/scripts"
+  path_to_configs = "../network-primitives-archive/configs"
   network_name    = "gemini-3g"
   bootstrap-node-config = {
     instance-type      = var.instance_type["bootstrap"]
@@ -9,7 +9,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2024-jan-03"
+    docker-tag         = "gemini-3g-2024-jan-08"
     reserved-only      = true
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -25,7 +25,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2024-jan-03"
+    docker-tag         = "gemini-3g-2024-jan-08"
     reserved-only      = false
     prune              = false
     genesis-hash       = "418040fc282f5e5ddd432c46d05297636f6f75ce68d66499ff4cbda69ccd180b"
@@ -42,7 +42,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2024-jan-03"
+    docker-tag         = "gemini-3g-2024-jan-08"
     reserved-only      = true
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2024-jan-03"
+    docker-tag         = "gemini-3g-2024-jan-08"
     domain-prefix      = "rpc"
     reserved-only      = true
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3g" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3g-2024-jan-03"
+    docker-tag         = "gemini-3g-2024-jan-08"
     domain-prefix      = "nova"
     reserved-only      = true
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3g" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3g-2024-jan-03"
+    docker-tag             = "gemini-3g-2024-jan-08"
     reserved-only          = true
     prune                  = false
     plot-size              = "2G"

--- a/aws/network-primitives-archive/ami.tf
+++ b/aws/network-primitives-archive/ami.tf
@@ -1,0 +1,20 @@
+data "aws_ami" "ubuntu_amd64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["099720109477"]
+}

--- a/aws/network-primitives-archive/bootstrap_node_evm_provisioner.tf
+++ b/aws/network-primitives-archive/bootstrap_node_evm_provisioner.tf
@@ -1,0 +1,171 @@
+locals {
+  bootstrap_nodes_evm_ip_v4 = flatten([
+    [aws_instance.bootstrap_node_evm.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-bootstrap-nodes-evm" {
+  count = length(local.bootstrap_nodes_evm_ip_v4)
+
+  depends_on = [aws_instance.bootstrap_node_evm]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.bootstrap_nodes_evm_ip_v4)
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_evm_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-bootstrap-nodes-evm" {
+  count      = var.bootstrap-node-evm-config.prune ? length(local.bootstrap_nodes_evm_ip_v4) : 0
+  depends_on = [null_resource.setup-bootstrap-nodes-evm]
+
+  triggers = {
+    prune = var.bootstrap-node-evm-config.prune
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_evm_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-bootstrap-nodes-evm" {
+  count = length(local.bootstrap_nodes_evm_ip_v4)
+
+  depends_on = [null_resource.setup-bootstrap-nodes-evm]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.bootstrap-node-evm-config.deployment-version
+    reserved_only      = var.bootstrap-node-evm-config.reserved-only
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_evm_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy bootstrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_evm_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy relayer ids
+  provisioner "file" {
+    source      = "./relayer_ids.txt"
+    destination = "/home/${var.ssh_user}/subspace/relayer_ids.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_bootstrap_node_evm_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-bootstrap-node-evm-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.bootstrap-node-evm-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.bootstrap-node-evm-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_LABEL=${var.domain-node-config.domain-labels[0]} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_ID=${var.domain-node-config.domain-id[0]} >> /home/${var.ssh_user}/subspace/.env",
+      "echo RELAYER_SYSTEM_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_SYSTEM_ID=//p' /home/${var.ssh_user}/subspace/relayer_ids.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo RELAYER_DOMAIN_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_DOMAIN_ID=//p' /home/${var.ssh_user}/subspace/relayer_ids.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_NODE_KEY=$(sed -nr 's/NODE_${count.index}_DSN_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_LISTEN_PORT=${var.bootstrap-node-evm-config.dsn-listen-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.bootstrap-node-evm-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo OPERATOR_PORT=${var.bootstrap-node-evm-config.operator-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo GENESIS_HASH=${var.bootstrap-node-evm-config.genesis-hash} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-evm-config.reserved-only} ${length(local.bootstrap_nodes_evm_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains} ",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/aws/network-primitives-archive/bootstrap_node_provisioner.tf
+++ b/aws/network-primitives-archive/bootstrap_node_provisioner.tf
@@ -1,0 +1,154 @@
+locals {
+  bootstrap_nodes_ip_v4 = flatten([
+    [aws_instance.bootstrap_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-bootstrap-nodes" {
+  count = length(local.bootstrap_nodes_ip_v4)
+
+  depends_on = [aws_instance.bootstrap_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.bootstrap_nodes_ip_v4)
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-bootstrap-nodes" {
+  count      = var.bootstrap-node-config.prune ? length(local.bootstrap_nodes_ip_v4) : 0
+  depends_on = [null_resource.setup-bootstrap-nodes]
+
+  triggers = {
+    prune = var.bootstrap-node-config.prune
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-boostrap-nodes" {
+  count = length(local.bootstrap_nodes_ip_v4)
+
+  depends_on = [null_resource.setup-bootstrap-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.bootstrap-node-config.deployment-version
+    reserved_only      = var.bootstrap-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.bootstrap_nodes_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy bootstrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_bootstrap_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-bootstrap-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.bootstrap-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.bootstrap-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_NODE_KEY=$(sed -nr 's/NODE_${count.index}_SUBSPACE_KEY=//p' /home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo DSN_LISTEN_PORT=${var.bootstrap-node-config.dsn-listen-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.bootstrap-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+      "echo GENESIS_HASH=${var.bootstrap-node-config.genesis-hash} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.bootstrap_nodes_ip_v4)} ${count.index}",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/aws/network-primitives-archive/configs/prometheus.yml
+++ b/aws/network-primitives-archive/configs/prometheus.yml
@@ -1,0 +1,8 @@
+# A scrape configuration for subspace node:
+scrape_configs:
+  - job_name: "subspace_node"
+
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ["localhost:9615"]

--- a/aws/network-primitives-archive/dns.tf
+++ b/aws/network-primitives-archive/dns.tf
@@ -1,0 +1,44 @@
+data "cloudflare_zone" "cloudflare_zone" {
+  name = "subspace.network"
+}
+
+resource "cloudflare_record" "rpc" {
+  count   = length(local.rpc_node_ip_v4)
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "${var.rpc-node-config.domain-prefix}-${count.index}.${var.network_name}"
+  value   = local.rpc_node_ip_v4[count.index]
+  type    = "A"
+}
+
+# Remove system domain
+# resource "cloudflare_record" "system-domain" {
+#   count   = length(local.domain_node_ip_v4)
+#   zone_id = data.cloudflare_zone.cloudflare_zone.id
+#   name    = "${var.domain-node-config.domain-prefix}-${count.index}.system.${var.network_name}"
+#   value   = local.domain_node_ip_v4[count.index]
+#   type    = "A"
+# }
+
+resource "cloudflare_record" "core-domain" {
+  count   = length(local.domain_node_ip_v4)
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "${var.domain-node-config.domain-prefix}.${var.network_name}"
+  value   = local.domain_node_ip_v4[count.index]
+  type    = "A"
+}
+
+resource "cloudflare_record" "bootstrap" {
+  count   = length(local.bootstrap_nodes_ip_v4)
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "bootstrap-${count.index}.${var.network_name}"
+  value   = local.bootstrap_nodes_ip_v4[count.index]
+  type    = "A"
+}
+
+resource "cloudflare_record" "bootstrap_evm" {
+  count   = length(local.bootstrap_nodes_evm_ip_v4)
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "bootstrap-${count.index}.nova.${var.network_name}"
+  value   = local.bootstrap_nodes_evm_ip_v4[count.index]
+  type    = "A"
+}

--- a/aws/network-primitives-archive/domain_node_provisioner.tf
+++ b/aws/network-primitives-archive/domain_node_provisioner.tf
@@ -1,0 +1,206 @@
+locals {
+  domain_node_ip_v4 = flatten([
+    [aws_instance.domain_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-domain-nodes" {
+  count = length(local.domain_node_ip_v4)
+
+  depends_on = [aws_instance.domain_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.domain_node_ip_v4)
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-domain-nodes" {
+  count      = var.domain-node-config.prune ? length(local.domain_node_ip_v4) : 0
+  depends_on = [null_resource.setup-domain-nodes]
+
+  triggers = {
+    prune = var.domain-node-config.prune
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-domain-nodes" {
+  count = length(local.domain_node_ip_v4)
+
+  depends_on = [null_resource.setup-domain-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.domain-node-config.deployment-version
+    reserved_only      = var.domain-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./domain_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_evm_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_evm_keys.txt"
+  }
+
+  # copy dsn_boostrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy keystore
+  provisioner "file" {
+    source      = "./keystore"
+    destination = "/home/${var.ssh_user}/subspace/keystore/"
+  }
+
+  # copy relayer ids
+  provisioner "file" {
+    source      = "./relayer_ids.txt"
+    destination = "/home/${var.ssh_user}/subspace/relayer_ids.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_domain_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-domain-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.domain-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.domain-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_PREFIX=${var.domain-node-config.domain-prefix} >> /home/${var.ssh_user}/subspace/.env",
+      # //todo use a map for domain id and labels
+      "echo DOMAIN_LABEL=${var.domain-node-config.domain-labels[0]} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_ID=${var.domain-node-config.domain-id[0]} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo RELAYER_SYSTEM_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_SYSTEM_ID=//p' /home/${var.ssh_user}/subspace/relayer_ids.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo RELAYER_DOMAIN_ID=$(sed -nr 's/NODE_${count.index}_RELAYER_DOMAIN_ID=//p' /home/${var.ssh_user}/subspace/relayer_ids.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.domain-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.domain_node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${length(local.bootstrap_nodes_evm_ip_v4)} ${var.domain-node-config.enable-domains} ${var.domain-node-config.domain-id[0]}",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}
+
+resource "null_resource" "inject-domain-keystore" {
+  # for now we have one executor running. Should change here when multiple executors are expected.
+  count      = length(local.domain_node_ip_v4) > 0 ? 1 : 0
+  depends_on = [null_resource.start-domain-nodes]
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.domain-node-config.deployment-version
+  }
+
+  connection {
+    host        = local.domain_node_ip_v4[0]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo docker cp /home/${var.ssh_user}/subspace/keystore-${count.index}/.  subspace-archival-node-1:/var/subspace/keystore/"
+    ]
+  }
+}

--- a/aws/network-primitives-archive/farmer_node_provisioner.tf
+++ b/aws/network-primitives-archive/farmer_node_provisioner.tf
@@ -1,0 +1,168 @@
+locals {
+  farmer_node_ipv4 = flatten([
+    [aws_instance.farmer_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-farmer-nodes" {
+  count = length(local.farmer_node_ipv4)
+
+  depends_on = [aws_instance.farmer_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.farmer_node_ipv4)
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/",
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/farmer_data/ && sudo chmod -R 770 /home/${var.ssh_user}/subspace/farmer_data/",
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-farmer-nodes" {
+  count      = var.farmer-node-config.prune ? length(local.farmer_node_ipv4) : 0
+  depends_on = [null_resource.setup-farmer-nodes]
+
+  triggers = {
+    prune = var.farmer-node-config.prune
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-farmer-nodes" {
+  count = length(local.farmer_node_ipv4)
+
+  depends_on = [null_resource.setup-farmer-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.farmer-node-config.deployment-version
+    reserved_only      = var.farmer-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.farmer_node_ipv4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy farmer identity files (todo: reset this after)
+  provisioner "file" {
+    source      = "./identity.bin"
+    destination = "/home/${var.ssh_user}/subspace/identity.bin"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./farmer_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_farmer_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # inject farmer identity // todo: make configurable as not needed with devnet
+      "sudo cp -rf /home/${var.ssh_user}/subspace/identity.bin  /home/${var.ssh_user}/subspace/farmer_data/",
+      "sudo chown -R nobody:nogroup /home/${var.ssh_user}/subspace/farmer_data/",
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-farmer-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.farmer-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.farmer-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/subspace/.env",
+      "echo REWARD_ADDRESS=${var.farmer-node-config.reward-address} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PLOT_SIZE=${var.farmer-node-config.plot-size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.farmer-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
+
+      # start subspace
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/aws/network-primitives-archive/full_node_provisioner.tf
+++ b/aws/network-primitives-archive/full_node_provisioner.tf
@@ -1,0 +1,155 @@
+locals {
+  full_node_ip_v4 = flatten([
+    [aws_instance.full_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-full-nodes" {
+  count = length(local.full_node_ip_v4)
+
+  depends_on = [aws_instance.full_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.full_node_ip_v4)
+  }
+
+  connection {
+    host        = local.full_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-full-nodes" {
+  count      = var.full-node-config.prune ? length(local.full_node_ip_v4) : 0
+  depends_on = [null_resource.setup-full-nodes]
+
+  triggers = {
+    prune = var.full-node-config.prune
+  }
+
+  connection {
+    host        = local.full_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-full-nodes" {
+  count = length(local.full_node_ip_v4)
+
+  depends_on = [null_resource.setup-full-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.full-node-config.deployment-version
+    reserved_only      = var.full-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.full_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./full_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_full_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-full-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.full-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.full-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.full-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.full_node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)}",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}

--- a/aws/network-primitives-archive/instances.tf
+++ b/aws/network-primitives-archive/instances.tf
@@ -1,0 +1,375 @@
+resource "aws_instance" "bootstrap_node" {
+  count             = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.bootstrap-node-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.bootstrap-node-config.disk-volume-size
+    volume_type = var.bootstrap-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+
+  tags = {
+    Name       = "${var.network_name}-bootstrap-${count.index}"
+    name       = "${var.network_name}-bootstrap-${count.index}"
+    role       = "bootstrap node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+resource "aws_instance" "bootstrap_node_evm" {
+  count             = length(var.aws_region) * var.bootstrap-node-evm-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.bootstrap-node-evm-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.bootstrap-node-config.disk-volume-size
+    volume_type = var.bootstrap-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+
+  tags = {
+    Name       = "${var.network_name}-bootstrap-evm-${count.index}"
+    name       = "${var.network_name}-bootstrap-evm-${count.index}"
+    role       = "bootstrap node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+resource "aws_instance" "full_node" {
+  count             = length(var.aws_region) * var.full-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.full-node-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.full-node-config.disk-volume-size
+    volume_type = var.full-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+  tags = {
+    Name       = "${var.network_name}-full-${count.index}"
+    name       = "${var.network_name}-full-${count.index}"
+    role       = "full node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+
+resource "aws_instance" "rpc_node" {
+  count             = length(var.aws_region) * var.rpc-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.rpc-node-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.rpc-node-config.disk-volume-size
+    volume_type = var.rpc-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+  tags = {
+    Name       = "${var.network_name}-rpc-${count.index}"
+    name       = "${var.network_name}-rpc-${count.index}"
+    role       = "rpc node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install curl gnupg openssl net-tools -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+
+resource "aws_instance" "domain_node" {
+  count             = length(var.aws_region) * var.domain-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.domain-node-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.domain-node-config.disk-volume-size
+    volume_type = var.domain-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+  tags = {
+    Name       = "${var.network_name}-domain-${count.index}"
+    name       = "${var.network_name}-domain-${count.index}"
+    role       = "domain node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}
+
+
+resource "aws_instance" "farmer_node" {
+  count             = length(var.aws_region) * var.farmer-node-config.instance-count
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.farmer-node-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = var.azs
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+  ebs_optimized               = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.farmer-node-config.disk-volume-size
+    volume_type = var.farmer-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+  tags = {
+    Name       = "${var.network_name}-farmer-${count.index}"
+    name       = "${var.network_name}-farmer-${count.index}"
+    role       = "farmer node"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    #aws_nat_gateway.nat_gateway,
+    aws_internet_gateway.gw
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ami]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+}

--- a/aws/network-primitives-archive/network.tf
+++ b/aws/network-primitives-archive/network.tf
@@ -1,0 +1,190 @@
+resource "aws_vpc" "network_vpc" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    name = "${var.network_name}-vpc"
+  }
+}
+
+resource "aws_subnet" "public_subnets" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.network_vpc.id
+  cidr_block              = element(var.public_subnet_cidrs, count.index)
+  availability_zone       = var.azs
+  map_public_ip_on_launch = "true"
+
+  tags = {
+    Name = "${var.network_name}-public-subnet-${count.index}"
+  }
+}
+
+
+resource "aws_internet_gateway" "gw" {
+  count  = length(var.public_subnet_cidrs)
+  vpc_id = aws_vpc.network_vpc.id
+
+  tags = {
+    Name = "${var.network_name}-igw-public-subnet-${count.index}"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_route_table" "public_route_table" {
+  count  = length(var.public_subnet_cidrs)
+  vpc_id = aws_vpc.network_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw[count.index].id
+  }
+
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.gw[count.index].id
+  }
+
+  tags = {
+    Name = "${var.network_name}-public-route-tbl-${count.index}"
+  }
+
+  depends_on = [
+    aws_internet_gateway.gw
+  ]
+}
+
+resource "aws_route_table_association" "public_route_table_subnets_association" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = element(aws_subnet.public_subnets.*.id, count.index)
+  route_table_id = element(aws_route_table.public_route_table.*.id, count.index)
+}
+
+resource "aws_security_group" "network_sg" {
+  name        = "${var.network_name}-network-sg"
+  description = "Allow HTTP and HTTPS inbound traffic"
+  vpc_id      = aws_vpc.network_vpc.id
+
+  ingress {
+    description = "HTTPS for VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP for VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "SSH for VPC"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Node Port 30333 for VPC"
+    from_port   = 30333
+    to_port     = 30333
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Node Port 30433 for VPC"
+    from_port   = 30433
+    to_port     = 30433
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Domain Operator Node Port 40333 for VPC"
+    from_port   = 40333
+    to_port     = 40333
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Farmer Port 30533 for VPC"
+    from_port   = 30533
+    to_port     = 30533
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # UDP ports
+
+  ingress {
+    description = "Node UDP Port 30333 for VPC"
+    from_port   = 30333
+    to_port     = 30333
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Node UDP Port 30433 for VPC"
+    from_port   = 30433
+    to_port     = 30433
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Farmer UDP Port 30533 for VPC"
+    from_port   = 30533
+    to_port     = 30533
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "egress for VPC"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.network_name}_sg"
+  }
+
+  depends_on = [
+    aws_vpc.network_vpc
+  ]
+}
+
+## Allocate EIP to NAT Gateway (NOTE: Disable for now since not using private VPC)
+
+# resource "aws_eip" "public_subnet_eip" {
+#   count = length(var.public_subnet_cidrs)
+#   vpc   = true
+
+#   depends_on = [
+#     aws_internet_gateway.gw,
+#   ]
+# }
+
+# # NAT Gateway for public subnet
+# resource "aws_nat_gateway" "nat_gateway" {
+#   count         = length(var.public_subnet_cidrs)
+#   allocation_id = element(aws_eip.public_subnet_eip.*.allocation_id, count.index)
+#   subnet_id     = element(aws_subnet.public_subnets.*.id, count.index)
+
+#   tags = {
+#     Name = "${var.network_name}-public-subnet-nat-GTW-${count.index}"
+#   }
+# }

--- a/aws/network-primitives-archive/outputs.tf
+++ b/aws/network-primitives-archive/outputs.tf
@@ -1,0 +1,108 @@
+// Output Variables
+
+output "bootstrap_node_server_id" {
+  value = aws_instance.bootstrap_node.*.id
+}
+
+output "bootstrap_node_public_ip" {
+  value = aws_instance.bootstrap_node.*.public_ip
+}
+
+output "bootstrap_node_private_ip" {
+  value = aws_instance.bootstrap_node.*.private_ip
+}
+
+output "bootstrap_node_ami" {
+  value = aws_instance.bootstrap_node.*.ami
+}
+
+output "bootstrap_node_evm_server_id" {
+  value = aws_instance.bootstrap_node_evm.*.id
+}
+
+output "bootstrap_node_evm_public_ip" {
+  value = aws_instance.bootstrap_node_evm.*.public_ip
+}
+
+output "bootstrap_node_evm_private_ip" {
+  value = aws_instance.bootstrap_node_evm.*.private_ip
+}
+
+output "bootstrap_node_evm_ami" {
+  value = aws_instance.bootstrap_node_evm.*.ami
+}
+
+output "full_node_server_id" {
+  value = aws_instance.full_node.*.id
+}
+
+output "full_node_private_ip" {
+  value = aws_instance.full_node.*.private_ip
+}
+
+output "full_node_public_ip" {
+  value = aws_instance.full_node.*.public_ip
+}
+
+output "full_node_ami" {
+  value = aws_instance.full_node.*.ami
+}
+
+
+output "rpc_node_server_id" {
+  value = aws_instance.rpc_node.*.id
+}
+
+output "rpc_node_private_ip" {
+  value = aws_instance.rpc_node.*.private_ip
+}
+
+output "rpc_node_public_ip" {
+  value = aws_instance.rpc_node.*.public_ip
+}
+
+output "rpc_node_ami" {
+  value = aws_instance.rpc_node.*.ami
+}
+
+
+output "domain_node_server_id" {
+  value = aws_instance.domain_node.*.id
+}
+
+output "domain_node_private_ip" {
+  value = aws_instance.domain_node.*.private_ip
+}
+
+output "domain_node_public_ip" {
+  value = aws_instance.domain_node.*.public_ip
+}
+
+output "domain_node_ami" {
+  value = aws_instance.domain_node.*.ami
+}
+
+
+output "farmer_node_server_id" {
+  value = aws_instance.farmer_node.*.id
+}
+
+output "farmer_node_private_ip" {
+  value = aws_instance.farmer_node.*.private_ip
+}
+
+output "farmer_node_public_ip" {
+  value = aws_instance.farmer_node.*.public_ip
+}
+
+output "farmer_node_ami" {
+  value = aws_instance.farmer_node.*.ami
+}
+
+output "dns-records" {
+  value = [
+    cloudflare_record.bootstrap.*.hostname,
+    cloudflare_record.rpc.*.hostname,
+    cloudflare_record.core-domain.*.hostname,
+  ]
+}

--- a/aws/network-primitives-archive/provider.tf
+++ b/aws/network-primitives-archive/provider.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.55.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">=4.7.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region[0]
+  default_tags {
+    tags = {
+      Environment = var.network_name
+      Owner       = "subspace"
+      Project     = "Subspace Gemini network"
+    }
+  }
+}
+
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/aws/network-primitives-archive/rpc_node_provisioner.tf
+++ b/aws/network-primitives-archive/rpc_node_provisioner.tf
@@ -1,0 +1,194 @@
+locals {
+  rpc_node_ip_v4 = flatten([
+    [aws_instance.rpc_node.*.public_ip]
+    ]
+  )
+}
+
+resource "null_resource" "setup-rpc-nodes" {
+  count = length(local.rpc_node_ip_v4)
+
+  depends_on = [aws_instance.rpc_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.rpc_node_ip_v4)
+  }
+
+  connection {
+    host        = local.rpc_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # create subspace dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/subspace/",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/subspace/ && sudo chmod -R 750 /home/${var.ssh_user}/subspace/"
+    ]
+  }
+
+  # copy install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/installer.sh"
+    destination = "/home/${var.ssh_user}/subspace/installer.sh"
+  }
+
+  # copy config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/"
+    destination = "/home/${var.ssh_user}/subspace/"
+  }
+
+  # install docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/installer.sh",
+    ]
+  }
+
+}
+
+resource "null_resource" "prune-rpc-nodes" {
+  count      = var.rpc-node-config.prune ? length(local.rpc_node_ip_v4) : 0
+  depends_on = [null_resource.setup-rpc-nodes]
+
+  triggers = {
+    prune = var.rpc-node-config.prune
+  }
+
+  connection {
+    host        = local.rpc_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/prune_docker_system.sh"
+    destination = "/home/${var.ssh_user}/subspace/prune_docker_system.sh"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /home/${var.ssh_user}/subspace/prune_docker_system.sh"
+    ]
+  }
+}
+
+resource "null_resource" "start-rpc-nodes" {
+  count = length(local.rpc_node_ip_v4)
+
+  depends_on = [null_resource.setup-rpc-nodes]
+
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.rpc-node-config.deployment-version
+    reserved_only      = var.rpc-node-config.reserved-only
+  }
+
+  connection {
+    host        = local.rpc_node_ip_v4[count.index]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  # copy node keys file
+  provisioner "file" {
+    source      = "./rpc_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/node_keys.txt"
+  }
+
+  # copy boostrap node keys file
+  provisioner "file" {
+    source      = "./bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/bootstrap_node_keys.txt"
+  }
+
+  # copy DSN bootstrap node keys file
+  provisioner "file" {
+    source      = "./dsn_bootstrap_node_keys.txt"
+    destination = "/home/${var.ssh_user}/subspace/dsn_bootstrap_node_keys.txt"
+  }
+
+  # copy keystore
+  provisioner "file" {
+    source      = "./keystore"
+    destination = "/home/${var.ssh_user}/subspace/keystore/"
+  }
+
+  # copy relayer ids
+  provisioner "file" {
+    source      = "./relayer_ids.txt"
+    destination = "/home/${var.ssh_user}/subspace/relayer_ids.txt"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_rpc_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/subspace/create_compose_file.sh"
+  }
+
+  # start docker containers
+  provisioner "remote-exec" {
+    inline = [
+      # stop any running service
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml down ",
+
+      # set hostname
+      "sudo hostnamectl set-hostname ${var.network_name}-rpc-node-${count.index}",
+
+      # create .env file
+      "echo NODE_ORG=${var.rpc-node-config.docker-org} > /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_TAG=${var.rpc-node-config.docker-tag} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/subspace/.env",
+      "echo DOMAIN_PREFIX=${var.rpc-node-config.domain-prefix} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_ID=${count.index} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_KEY=$(sed -nr 's/NODE_${count.index}_KEY=//p' /home/${var.ssh_user}/subspace/node_keys.txt) >> /home/${var.ssh_user}/subspace/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/subspace/.env",
+      "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /home/${var.ssh_user}/subspace/.env",
+      "echo NODE_DSN_PORT=${var.rpc-node-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
+
+      # create docker compose file
+      "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.rpc_node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)}",
+
+      # start subspace node
+      "sudo docker compose -f /home/${var.ssh_user}/subspace/docker-compose.yml up -d",
+    ]
+  }
+}
+
+resource "null_resource" "inject-keystore" {
+  # for now we have one executor running. Should change here when multiple executors are expected.
+  count      = length(local.rpc_node_ip_v4) > 0 ? 1 : 0
+  depends_on = [null_resource.start-rpc-nodes]
+  # trigger on node deployment version change
+  triggers = {
+    deployment_version = var.rpc-node-config.deployment-version
+  }
+
+  connection {
+    host        = local.rpc_node_ip_v4[0]
+    user        = var.ssh_user
+    type        = "ssh"
+    agent       = true
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo docker cp /home/${var.ssh_user}/subspace/keystore/.  subspace-archival-node-1:/var/subspace/keystore/"
+    ]
+  }
+}

--- a/aws/network-primitives-archive/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives-archive/scripts/create_bootstrap_node_compose_file.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  vmagentdata: {}
+
+services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--httpListenAddr=0.0.0.0:8429"
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "\${NETWORK_NAME}-bootstrap-node-\${NODE_ID}"
+    restart: unless-stopped
+
+  dsn-bootstrap-node:
+    image: ghcr.io/\${NODE_ORG}/bootstrap-node:\${NODE_TAG}
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=info
+    ports:
+      - "30533:30533/udp"
+      - "30533:30533/tcp"
+      - "9616:9616"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command:
+      - start
+      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--keypair"
+      - \${DSN_NODE_KEY}
+      - "--listen-on"
+      - /ip4/0.0.0.0/udp/30533/quic-v1
+      - "--listen-on"
+      - /ip4/0.0.0.0/tcp/30533
+      - --protocol-version
+      - \${GENESIS_HASH}
+      - "--in-peers"
+      - "1000"
+      - "--out-peers"
+      - "1000"
+      - "--pending-in-peers"
+      - "1000"
+      - "--pending-out-peers"
+      - "1000"
+## comment to disable external addresses using IP format for now
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/tcp/30533"
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--reserved-peers\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"--bootstrap-nodes\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+cat >> ~/subspace/docker-compose.yml << EOF
+  archival-node:
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/udp"
+      - "30433:30433/tcp"
+      - "9615:9615"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--in-peers-light", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+    echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  fi
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives-archive/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/aws/network-primitives-archive/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+enable_domains=${5}
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  vmagentdata: {}
+
+services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--httpListenAddr=0.0.0.0:8429"
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "\${NETWORK_NAME}-bootstrap-node-evm\${NODE_ID}"
+    restart: unless-stopped
+
+  dsn-bootstrap-node:
+    image: ghcr.io/\${NODE_ORG}/bootstrap-node:\${NODE_TAG}
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=info
+    ports:
+      - "30533:30533/tcp"
+      - "30533:30533/udp"
+      - "9616:9616"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command:
+      - start
+      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--keypair"
+      - \${DSN_NODE_KEY}
+      - "--listen-on"
+      - /ip4/0.0.0.0/udp/30533/quic-v1
+      - "--listen-on"
+      - /ip4/0.0.0.0/tcp/30533
+      - --protocol-version
+      - \${GENESIS_HASH}
+      - "--in-peers"
+      - "1000"
+      - "--out-peers"
+      - "1000"
+      - "--pending-in-peers"
+      - "1000"
+      - "--pending-out-peers"
+      - "1000"
+      - "--external-address"
+      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
+      - "--external-address"
+      - "/ip4/$EXTERNAL_IP/tcp/30533"
+EOF
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--reserved-peers\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"--bootstrap-nodes\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+cat >> ~/subspace/docker-compose.yml << EOF
+  archival-node:
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/udp"
+      - "30433:30433/tcp"
+      - "\${OPERATOR_PORT}:40333/tcp"
+      - "9615:9615"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--in-peers-light", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
+EOF
+
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_keys.txt)
+    echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${enable_domains}" == "true" ]; then
+    {
+    # core domain
+      echo '      "--",'
+      echo '      "--chain=${NETWORK_NAME}",'
+      echo '      "--node-key", "${NODE_KEY}",'
+    #  echo '      "--enable-subspace-block-relay",'
+      echo '      "--state-pruning", "archive",'
+      echo '      "--blocks-pruning", "archive",'
+      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
+      echo '      "--domain-id", "${DOMAIN_ID}",'
+      echo '      "--base-path", "/var/subspace",'
+      echo '      "--rpc-cors", "all",'
+      echo '      "--rpc-port", "8944",'
+      echo '      "--unsafe-rpc-external",'
+      echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+    for (( i = 0; i <  node_count; i++ )); do
+      addr=$(sed -nr "s/NODE_${i}_OPERATOR_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    done
+
+    }  >> ~/subspace/docker-compose.yml
+fi
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives-archive/scripts/create_domain_node_compose_file.sh
+++ b/aws/network-primitives-archive/scripts/create_domain_node_compose_file.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  vmagentdata: {}
+
+networks:
+  traefik-proxy:
+    external: true
+
+services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--httpListenAddr=0.0.0.0:8429"
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "\${NETWORK_NAME}-domain-node-\${NODE_ID}"
+    restart: unless-stopped
+
+  # traefik reverse proxy with automatic tls management using let encrypt
+  traefik:
+    image: traefik:v2.10
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      - --api=false
+      - --api.dashboard=false
+      - --providers.docker
+      - --log.level=info
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entryPoint.to=websecure
+      - --entrypoints.websecure.address=:443
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --certificatesresolvers.le.acme.email=alerts@subspace.network
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.tlschallenge=true
+    networks:
+      - traefik-proxy
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./letsencrypt:/letsencrypt
+
+  archival-node:
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/tcp"
+      - "30333:30333/udp"
+      - "30433:30433/tcp"
+      - "30433:30433/udp"
+      - "40333:40333/tcp"
+      - "9615:9615"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.archival-node.loadbalancer.server.port=8944"
+      - "traefik.http.routers.archival-node.rule=Host(`${DOMAIN_PREFIX}-${DOMAIN_ID}.${DOMAIN_LABEL}.${NETWORK_NAME}.subspace.network`) && Path(`/ws`)"
+      - "traefik.http.routers.archival-node.tls=true"
+      - "traefik.http.routers.archival-node.tls.certresolver=le"
+      - "traefik.http.routers.archival-node.entrypoints=websecure"
+      - "traefik.http.routers.archival-node.middlewares=redirect-https"
+      - "traefik.http.middlewares.redirect-https.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.redirect-https.redirectscheme.permanent=true"
+    networks:
+      - traefik-proxy
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+bootstrap_node_evm_count=${5}
+enable_domains=${6}
+domain_id=${7}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == "true" ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${enable_domains}" == "true" ]; then
+  {
+    # core domain
+    echo '      "--",'
+    echo '      "--chain=${NETWORK_NAME}",'
+    #  echo '      "--enable-subspace-block-relay",'
+    echo '      "--state-pruning", "archive",'
+    echo '      "--blocks-pruning", "archive",'
+    echo '      "--domain-id", "${DOMAIN_ID}",'
+    echo '      "--operator",'
+    echo '      "--keystore-path", "/var/subspace/keystore",'
+    echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_${DOMAIN_ID}_domain",'
+    echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",'
+    echo '      "--rpc-cors", "all",'
+    echo '      "--rpc-port", "8944",'
+    echo '      "--unsafe-rpc-external",'
+    echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+
+    for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
+      addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_evm_keys.txt)
+      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    done
+
+  } >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives-archive/scripts/create_farmer_node_compose_file.sh
+++ b/aws/network-primitives-archive/scripts/create_farmer_node_compose_file.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  farmer_data: {}
+  vmagentdata: {}
+
+services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--httpListenAddr=0.0.0.0:8429"
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "\${NETWORK_NAME}-farmer-node-\${NODE_ID}"
+    restart: unless-stopped
+
+  farmer:
+    depends_on:
+      archival-node:
+        condition: service_healthy
+    image: ghcr.io/\${NODE_ORG}/farmer:\${NODE_TAG}
+    volumes:
+      - /home/$USER/subspace/farmer_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30533:30533/udp"
+      - "30533:30533/tcp"
+      - "9616:9616"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "farm", "path=/var/subspace,size=\${PLOT_SIZE}",
+      "--node-rpc-url", "ws://archival-node:9944",
+      "--external-address", "/ip4/$EXTERNAL_IP/udp/30533/quic-v1",
+      "--external-address", "/ip4/$EXTERNAL_IP/tcp/30533",
+      "--listen-on", "/ip4/0.0.0.0/udp/30533/quic-v1",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30533",
+      "--reward-address", "\${REWARD_ADDRESS}",
+      "--metrics-endpoint=0.0.0.0:9616",
+      "--cache-percentage", "15",
+    ]
+
+  archival-node:
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/udp"
+      - "30433:30433/tcp"
+      - "9615:9615"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--validator",
+      "--timekeeper",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--rpc-methods", "unsafe",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+force_block_production=${5}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+  echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+if [ "${force_block_production}" == true ]; then
+  echo "      \"--force-synced\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--force-authoring\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives-archive/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives-archive/scripts/create_full_node_compose_file.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  vmagentdata: {}
+
+services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--httpListenAddr=0.0.0.0:8429"
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "\${NETWORK_NAME}-full-node-\${NODE_ID}"
+    restart: unless-stopped
+
+  archival-node:
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/udp"
+      - "30433:30433/tcp"
+      - "9615:9615"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives-archive/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives-archive/scripts/create_rpc_node_compose_file.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  vmagentdata: {}
+
+networks:
+  traefik-proxy:
+    external: true
+
+services:
+  vmagent:
+    container_name: vmagent
+    image: victoriametrics/vmagent:latest
+    depends_on:
+      - "archival-node"
+    ports:
+      - 8429:8429
+    volumes:
+      - vmagentdata:/vmagentdata
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--httpListenAddr=0.0.0.0:8429"
+      - "--promscrape.config=/etc/prometheus/prometheus.yml"
+      - "--remoteWrite.url=http://vmetrics.subspace.network:8428/api/v1/write"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "\${NETWORK_NAME}-rpc-node-\${NODE_ID}"
+    restart: unless-stopped
+
+  # traefik reverse proxy with automatic tls management using let encrypt
+  traefik:
+    image: traefik:v2.10
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      - --api=false
+      - --api.dashboard=false
+      - --providers.docker
+      - --log.level=info
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entryPoint.to=websecure
+      - --entrypoints.websecure.address=:443
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --certificatesresolvers.le.acme.email=alerts@subspace.network
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.tlschallenge=true
+    networks:
+      - traefik-proxy
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./letsencrypt:/letsencrypt
+
+  archival-node:
+    image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.archival-node.loadbalancer.server.port=9944"
+      - "traefik.http.routers.archival-node.rule=Host(`${DOMAIN_PREFIX}-${NODE_ID}.${NETWORK_NAME}.subspace.network`) && Path(`/ws`)"
+      - "traefik.http.routers.archival-node.tls=true"
+      - "traefik.http.routers.archival-node.tls.certresolver=le"
+      - "traefik.http.routers.archival-node.entrypoints=websecure"
+      - "traefik.http.routers.archival-node.middlewares=redirect-https"
+      - "traefik.http.middlewares.redirect-https.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.redirect-https.redirectscheme.permanent=true"
+    ports:
+      - "9615:9615"
+    networks:
+      - traefik-proxy
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command: [
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--execution", "wasm",
+#      "--enable-subspace-block-relay",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--node-key", "\${NODE_KEY}",
+      "--rpc-cors", "all",
+      "--rpc-external",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--in-peers-light", "500",
+      "--rpc-max-connections", "10000",
+      "--prometheus-port", "9615",
+      "--prometheus-external",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives-archive/scripts/installer.sh
+++ b/aws/network-primitives-archive/scripts/installer.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# updates
+export DEBIAN_FRONTEND=noninteractive
+sudo apt update -y
+sudo apt install curl gnupg openssl net-tools -y
+
+# install docker & Docker Compose
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update -y
+sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+
+# set max socket connections
+if ! (grep -iq "net.core.somaxconn" /etc/sysctl.conf && sed -i 's/.*net.core.somaxconn.*/net.core.somaxconn=65535/' /etc/sysctl.conf); then
+  sudo echo "net.core.somaxconn=65535" >> /etc/sysctl.conf
+fi
+
+sudo sysctl -p /etc/sysctl.conf
+
+sudo docker plugin install grafana/loki-docker-driver:2.9.1 --alias loki --grant-all-permissions

--- a/aws/network-primitives-archive/scripts/prune_docker_system.sh
+++ b/aws/network-primitives-archive/scripts/prune_docker_system.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+sudo docker ps -aq | xargs sudo docker update --restart=no
+# stop all the containers
+sudo docker compose down
+# prune everything docker related
+sudo docker system prune -a -f
+sudo docker volume ls -q | grep -v traefik | xargs sudo docker volume rm -f
+# remove key files
+sudo rm -rf ~/subspace/*_keys.txt

--- a/aws/network-primitives-archive/variables.tf
+++ b/aws/network-primitives-archive/variables.tf
@@ -1,0 +1,221 @@
+variable "nr_api_key" {
+  description = "New relic API Key"
+  type        = string
+}
+
+variable "cloudflare_email" {
+  type        = string
+  description = "cloudflare email address"
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "cloudflare api token"
+}
+
+variable "instance_type" {
+  type = map(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  type = string
+}
+
+variable "azs" {
+  type        = string
+  description = "Availability Zones"
+  default     = "us-east-1a"
+}
+
+variable "instance_count" {
+  type = map(number)
+  default = {
+    bootstrap     = 2
+    rpc           = 2
+    domain        = 2
+    full          = 1
+    farmer        = 1
+    evm_bootstrap = 1
+  }
+}
+
+variable "aws_region" {
+  description = "aws region"
+  type        = list(string)
+  default     = ["us-east-1"]
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public Subnet CIDR values"
+}
+
+variable "disk_volume_type" {
+  type    = string
+  default = "gp3"
+}
+
+variable "aws_key_name" {
+  default = "deployer"
+  type    = string
+}
+
+variable "ssh_user" {
+  default = "ubuntu"
+  type    = string
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/deployer.pem"
+}
+
+variable "network_name" {
+  description = "Network name"
+  type        = string
+}
+
+variable "path_to_scripts" {
+  description = "Path to the scripts"
+  type        = string
+}
+
+variable "path_to_configs" {
+  description = "Path to the configs"
+  type        = string
+}
+
+variable "piece_cache_size" {
+  description = "Piece cache size"
+  type        = string
+  default     = "1GiB"
+}
+
+variable "full-node-config" {
+  description = "Full node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    reserved-only      = bool
+    prune              = bool
+    node-dsn-port      = number
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "rpc-node-config" {
+  description = "RPC node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    domain-prefix      = string
+    reserved-only      = bool
+    prune              = bool
+    node-dsn-port      = number
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "domain-node-config" {
+  description = "Domain node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    domain-prefix      = string
+    reserved-only      = bool
+    prune              = bool
+    node-dsn-port      = number
+    enable-domains     = bool
+    domain-id          = list(number)
+    domain-labels      = list(string)
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "bootstrap-node-config" {
+  description = "Bootstrap node deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    reserved-only      = bool
+    prune              = bool
+    genesis-hash       = string
+    dsn-listen-port    = number
+    node-dsn-port      = number
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "bootstrap-node-evm-config" {
+  description = "Bootstrap node evm domain deployment config"
+  type = object({
+    instance-type      = string
+    deployment-version = number
+    regions            = list(string)
+    instance-count     = number
+    docker-org         = string
+    docker-tag         = string
+    reserved-only      = bool
+    prune              = bool
+    genesis-hash       = string
+    dsn-listen-port    = number
+    node-dsn-port      = number
+    operator-port      = number
+    disk-volume-size   = number
+    disk-volume-type   = string
+  })
+}
+
+variable "farmer-node-config" {
+  description = "Farmer and Node configuration"
+  type = object({
+    instance-type          = string
+    deployment-version     = number
+    regions                = list(string)
+    instance-count         = number
+    docker-org             = string
+    docker-tag             = string
+    reserved-only          = bool
+    prune                  = bool
+    plot-size              = string
+    reward-address         = string
+    force-block-production = bool
+    node-dsn-port          = number
+    disk-volume-size       = number
+    disk-volume-type       = string
+  })
+}
+
+variable "secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "access_key" {
+  type      = string
+  sensitive = true
+}

--- a/aws/network-primitives/network.tf
+++ b/aws/network-primitives/network.tf
@@ -109,6 +109,14 @@ resource "aws_security_group" "network_sg" {
   }
 
   ingress {
+    description = "Node Port 30334 Domain port for VPC"
+    from_port   = 30334
+    to_port     = 30334
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     description = "Domain Operator Node Port 40333 for VPC"
     from_port   = 40333
     to_port     = 40333
@@ -141,6 +149,15 @@ resource "aws_security_group" "network_sg" {
     protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  ingress {
+    description = "Node UDP Port 30334 Domain port for VPC"
+    from_port   = 30334
+    to_port     = 30334
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
 
   ingress {
     description = "Farmer UDP Port 30533 for VPC"

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -122,6 +122,7 @@ cat >> ~/subspace/docker-compose.yml << EOF
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--state-pruning", "archive",
@@ -132,7 +133,6 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
-      "--in-peers-light", "1000",
       "--dsn-in-connections", "1000",
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -124,14 +124,11 @@ cat >> ~/subspace/docker-compose.yml << EOF
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
@@ -140,15 +137,14 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--prometheus-listen-on", "9615",
 EOF
 
 for (( i = 0; i < node_count; i++ )); do
   if [ "${current_node}" != "${i}" ]; then
     addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
     echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
   fi
 done
 

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -137,7 +137,7 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--prometheus-listen-on", "9615",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 for (( i = 0; i < node_count; i++ )); do

--- a/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -127,7 +127,7 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--prometheus-listen-on", "9615",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 
@@ -151,14 +151,14 @@ if [ "${enable_domains}" == "true" ]; then
     {
     # core domain
       echo '      "--",'
-      echo '      "--domain-id=${DOMAIN_ID}",'
+      echo '      "--domain-id", "${DOMAIN_ID}",'
       echo '      "--node-key", "${NODE_KEY}",'
       echo '      "--state-pruning", "archive",'
       echo '      "--blocks-pruning", "archive",'
       echo '      "--listen-on", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
-      echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
+      echo '      "--base-path", "/var/subspace/",'
       echo '      "--rpc-cors", "all",'
-      echo '      "--rpc-listen-on", "8944",'
+      echo '      "--rpc-listen-on", "127.0.0.1:8944",'
       echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
     for (( i = 0; i <  node_count; i++ )); do
       addr=$(sed -nr "s/NODE_${i}_OPERATOR_MULTI_ADDR=//p" ~/subspace/node_keys.txt)

--- a/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -79,11 +79,24 @@ services:
       - "1000"
       - "--pending-out-peers"
       - "1000"
-      - "--external-address"
-      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
-      - "--external-address"
-      - "/ip4/$EXTERNAL_IP/tcp/30533"
+## comment to disable external addresses using IP format for now
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/tcp/30533"
 EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
 for (( i = 0; i < node_count; i++ )); do
   if [ "${current_node}" != "${i}" ]; then
     dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
@@ -118,12 +131,13 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
       "--listen-on", "/ip4/0.0.0.0/tcp/30333",
-      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
-      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
       "--in-peers-light", "1000",
+## comment to disable external addresses using IP format for now
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
       "--dsn-in-connections", "1000",
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
@@ -131,6 +145,16 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
 
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_keys.txt)

--- a/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -114,14 +114,11 @@ cat >> ~/subspace/docker-compose.yml << EOF
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
@@ -130,15 +127,14 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--prometheus-listen-on", "9615",
 EOF
 
 
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_keys.txt)
     echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
@@ -155,22 +151,19 @@ if [ "${enable_domains}" == "true" ]; then
     {
     # core domain
       echo '      "--",'
-      echo '      "--chain=${NETWORK_NAME}",'
+      echo '      "--domain-id=${DOMAIN_ID}",'
       echo '      "--node-key", "${NODE_KEY}",'
-    #  echo '      "--enable-subspace-block-relay",'
       echo '      "--state-pruning", "archive",'
       echo '      "--blocks-pruning", "archive",'
-      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
-      echo '      "--domain-id=${DOMAIN_ID}",'
+      echo '      "--listen-on", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
       echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
       echo '      "--rpc-cors", "all",'
-      echo '      "--rpc-port", "8944",'
-      echo '      "--unsafe-rpc-external",'
+      echo '      "--rpc-listen-on", "8944",'
       echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
     for (( i = 0; i <  node_count; i++ )); do
       addr=$(sed -nr "s/NODE_${i}_OPERATOR_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
       echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
     done
 
     }  >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -105,13 +105,14 @@ cat >> ~/subspace/docker-compose.yml << EOF
       - "30333:30333/tcp"
       - "30433:30433/udp"
       - "30433:30433/tcp"
-      - "\${OPERATOR_PORT}:40333/tcp"
+      - "\${OPERATOR_PORT}:30334/tcp"
       - "9615:9615"
     logging:
       driver: loki
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--state-pruning", "archive",
@@ -152,14 +153,11 @@ if [ "${enable_domains}" == "true" ]; then
     # core domain
       echo '      "--",'
       echo '      "--domain-id", "${DOMAIN_ID}",'
-      echo '      "--node-key", "${NODE_KEY}",'
       echo '      "--state-pruning", "archive",'
       echo '      "--blocks-pruning", "archive",'
       echo '      "--listen-on", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
-      echo '      "--base-path", "/var/subspace/",'
       echo '      "--rpc-cors", "all",'
-      echo '      "--rpc-listen-on", "127.0.0.1:8944",'
-      echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+      echo '      "--rpc-listen-on", "0.0.0.0:8944",'
     for (( i = 0; i <  node_count; i++ )); do
       addr=$(sed -nr "s/NODE_${i}_OPERATOR_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
       echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives/scripts/create_domain_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_domain_node_compose_file.sh
@@ -114,9 +114,9 @@ services:
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
       "--rpc-cors", "all",
-      "--rpc-listen-on",
-      "--rpc-methods", "auto",
-      "--prometheus-listen-on", "9615",
+      "--rpc-listen-on", "127.0.0.1:9944",
+      "--rpc-methods", "safe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 reserved_only=${1}
@@ -148,7 +148,7 @@ if [ "${enable_domains}" == "true" ]; then
   {
     # core domain
     echo '      "--",'
-    echo '      "--domain-id=${DOMAIN_ID}",'
+    echo '      "--domain-id", "${DOMAIN_ID}",'
     echo '      "--state-pruning", "archive",'
     echo '      "--blocks-pruning", "archive",'
     echo '      "--operator",'
@@ -156,7 +156,7 @@ if [ "${enable_domains}" == "true" ]; then
     echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_${DOMAIN_ID}_domain",'
     echo '      "--listen-on", "/ip4/0.0.0.0/tcp/30334",'
     echo '      "--rpc-cors", "all",'
-    echo '      "--rpc-listen-on", "8944",'
+    echo '      "--rpc-listen-on", "127.0.0.1:8944",'
     echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
 
     for (( i = 0; i < bootstrap_node_evm_count; i++ )); do

--- a/aws/network-primitives/scripts/create_domain_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_domain_node_compose_file.sh
@@ -107,8 +107,9 @@ services:
       "--state-pruning", "archive",
       "--blocks-pruning", "archive",
       "--listen-on", "/ip4/0.0.0.0/tcp/30333",
-      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
-      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+## comment to disable external addresses using IP format for now
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "500",
       "--out-peers", "250",
@@ -128,6 +129,15 @@ dsn_bootstrap_node_count=${4}
 bootstrap_node_evm_count=${5}
 enable_domains=${6}
 domain_id=${7}
+
+for (( i = 0; i < node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+  echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+  echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+done
 
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)

--- a/aws/network-primitives/scripts/create_domain_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_domain_node_compose_file.sh
@@ -82,7 +82,7 @@ services:
       - "30333:30333/udp"
       - "30433:30433/tcp"
       - "30433:30433/udp"
-      - "40333:40333/tcp"
+      - "30334:30334/tcp"
       - "9615:9615"
     labels:
       - "traefik.enable=true"
@@ -101,6 +101,7 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--state-pruning", "archive",
@@ -114,7 +115,7 @@ services:
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
       "--rpc-cors", "all",
-      "--rpc-listen-on", "127.0.0.1:9944",
+      "--rpc-listen-on", "0.0.0.0:9944",
       "--rpc-methods", "safe",
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
@@ -151,13 +152,11 @@ if [ "${enable_domains}" == "true" ]; then
     echo '      "--domain-id", "${DOMAIN_ID}",'
     echo '      "--state-pruning", "archive",'
     echo '      "--blocks-pruning", "archive",'
-    echo '      "--operator",'
-    echo '      "--keystore-path", "/var/subspace/keystore",'
-    echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_${DOMAIN_ID}_domain",'
+    echo '      "--operator-id", "0",'
     echo '      "--listen-on", "/ip4/0.0.0.0/tcp/30334",'
     echo '      "--rpc-cors", "all",'
-    echo '      "--rpc-listen-on", "127.0.0.1:8944",'
-    echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+    echo '      "--rpc-methods", "safe",'
+    echo '      "--rpc-listen-on", "0.0.0.0:8944",'
 
     for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
       addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_evm_keys.txt)

--- a/aws/network-primitives/scripts/create_domain_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_domain_node_compose_file.sh
@@ -103,23 +103,20 @@ services:
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "archive",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
-      "--rpc-cors", "all",
-      "--rpc-external",
       "--in-peers", "500",
       "--out-peers", "250",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--rpc-cors", "all",
+      "--rpc-listen-on",
+      "--rpc-methods", "auto",
+      "--prometheus-listen-on", "9615",
 EOF
 
 reserved_only=${1}
@@ -134,7 +131,7 @@ domain_id=${7}
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
@@ -151,24 +148,21 @@ if [ "${enable_domains}" == "true" ]; then
   {
     # core domain
     echo '      "--",'
-    echo '      "--chain=${NETWORK_NAME}",'
-    #  echo '      "--enable-subspace-block-relay",'
+    echo '      "--domain-id=${DOMAIN_ID}",'
     echo '      "--state-pruning", "archive",'
     echo '      "--blocks-pruning", "archive",'
-    echo '      "--domain-id=${DOMAIN_ID}",'
     echo '      "--operator",'
     echo '      "--keystore-path", "/var/subspace/keystore",'
     echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_${DOMAIN_ID}_domain",'
-    echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/40333",'
+    echo '      "--listen-on", "/ip4/0.0.0.0/tcp/30334",'
     echo '      "--rpc-cors", "all",'
-    echo '      "--rpc-port", "8944",'
-    echo '      "--unsafe-rpc-external",'
+    echo '      "--rpc-listen-on", "8944",'
     echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
 
     for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
       addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_evm_keys.txt)
       echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
     done
 
   } >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
@@ -86,6 +86,7 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--state-pruning", "archive",
@@ -97,8 +98,8 @@ services:
       "--farmer",
       "--timekeeper",
       "--rpc-cors", "all",
-      "--rpc-listen-on", "127.0.0.1:9944",
-      "--rpc-methods", "safe",
+      "--rpc-listen-on", "0.0.0.0:9944",
+      "--rpc-methods", "unsafe",
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 

--- a/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
@@ -88,22 +88,18 @@ services:
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
-      "--validator",
+      "--farmer",
       "--timekeeper",
       "--rpc-cors", "all",
-      "--rpc-external",
-      "--rpc-methods", "unsafe",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--rpc-listen-on",
+      "--rpc-methods", "auto",
+      "--prometheus-listen-on", "9615",
 EOF
 
 reserved_only=${1}
@@ -116,7 +112,7 @@ force_block_production=${5}
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 # // TODO: make configurable with gemini network

--- a/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_farmer_node_compose_file.sh
@@ -97,9 +97,9 @@ services:
       "--farmer",
       "--timekeeper",
       "--rpc-cors", "all",
-      "--rpc-listen-on",
-      "--rpc-methods", "auto",
-      "--prometheus-listen-on", "9615",
+      "--rpc-listen-on", "127.0.0.1:9944",
+      "--rpc-methods", "safe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 reserved_only=${1}

--- a/aws/network-primitives/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_full_node_compose_file.sh
@@ -73,7 +73,7 @@ services:
       "--dsn-pending-out-connections", "1000",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
-      "--prometheus-listen-on", "9615",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 reserved_only=${1}

--- a/aws/network-primitives/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_full_node_compose_file.sh
@@ -57,6 +57,7 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--state-pruning", "archive",
@@ -71,7 +72,6 @@ services:
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF

--- a/aws/network-primitives/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_full_node_compose_file.sh
@@ -59,14 +59,11 @@ services:
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
@@ -76,8 +73,7 @@ services:
       "--dsn-pending-out-connections", "1000",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--prometheus-listen-on", "9615",
 EOF
 
 reserved_only=${1}
@@ -89,7 +85,7 @@ dsn_bootstrap_node_count=${4}
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 # // TODO: make configurable with gemini network as it's not needed for devnet

--- a/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
@@ -109,9 +109,9 @@ services:
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
       "--rpc-cors", "all",
-      "--rpc-listen-on",
-      "--rpc-methods", "auto",
-      "--prometheus-listen-on", "9615",
+      "--rpc-listen-on", "127.0.0.1:9944",
+      "--rpc-methods", "safe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 reserved_only=${1}

--- a/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
@@ -98,23 +98,20 @@ services:
     command: [
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "archive",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
       "--node-key", "\${NODE_KEY}",
-      "--rpc-cors", "all",
-      "--rpc-external",
       "--in-peers", "500",
       "--out-peers", "250",
       "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--rpc-cors", "all",
+      "--rpc-listen-on",
+      "--rpc-methods", "auto",
+      "--prometheus-listen-on", "9615",
 EOF
 
 reserved_only=${1}
@@ -126,7 +123,7 @@ dsn_bootstrap_node_count=${4}
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 # // TODO: make configurable with gemini network as it's not needed for devnet

--- a/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
@@ -96,6 +96,7 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
       "--state-pruning", "archive",
@@ -106,10 +107,9 @@ services:
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "500",
       "--out-peers", "250",
-      "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
       "--rpc-cors", "all",
-      "--rpc-listen-on", "127.0.0.1:9944",
+      "--rpc-listen-on", "0.0.0.0:9944",
       "--rpc-methods", "safe",
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF


### PR DESCRIPTION
This PR updates the parameters for consensus node and domain nodes respective of the cli changes in [#2408](https://github.com/subspace/subspace/pull/2408) and [#2412](https://github.com/subspace/subspace/pull/2412)

closes https://github.com/subspace/infra/pull/236

Major changes:
- adds a module `network-primitives-archive` to backport support older networks, i.e `gemini-3g` and `gemini-3f` since the upcoming CLI changes support next iteration of devnet and gemini-3h and has breaking changes to the existing module docker-compose deployments.
- Add domain names instead of IPs for domain RPC/bootstrap nodes(https://github.com/subspace/infra/pull/235/commits/20f570874052d0a7afcbbea89fda6d45a661b318)