### PR TITLE
add IPv6 support to network

### DIFF
--- a/aws/network-primitives/instances.tf
+++ b/aws/network-primitives/instances.tf
@@ -1,9 +1,10 @@
 resource "aws_instance" "bootstrap_node" {
-  count             = length(var.aws_region) * var.bootstrap-node-config.instance-count
-  ami               = data.aws_ami.ubuntu_amd64.image_id
-  instance_type     = var.bootstrap-node-config.instance-type
-  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
-  availability_zone = var.azs
+  count              = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ami                = data.aws_ami.ubuntu_amd64.image_id
+  instance_type      = var.bootstrap-node-config.instance-type
+  subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone  = var.azs
+  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
@@ -53,7 +54,7 @@ resource "aws_instance" "bootstrap_node" {
   # Setting up the ssh connection
   connection {
     type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
+    host        = coalesc(element(self.*.public_ip, count.index), element(self.*.ipv6_address, count.index))
     user        = var.ssh_user
     private_key = file("${var.private_key_path}")
     timeout     = "300s"
@@ -62,11 +63,12 @@ resource "aws_instance" "bootstrap_node" {
 }
 
 resource "aws_instance" "bootstrap_node_evm" {
-  count             = length(var.aws_region) * var.bootstrap-node-evm-config.instance-count
-  ami               = data.aws_ami.ubuntu_amd64.image_id
-  instance_type     = var.bootstrap-node-evm-config.instance-type
-  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
-  availability_zone = var.azs
+  count              = length(var.aws_region) * var.bootstrap-node-evm-config.instance-count
+  ami                = data.aws_ami.ubuntu_amd64.image_id
+  instance_type      = var.bootstrap-node-evm-config.instance-type
+  subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone  = var.azs
+  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
@@ -116,7 +118,7 @@ resource "aws_instance" "bootstrap_node_evm" {
   # Setting up the ssh connection
   connection {
     type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
+    host        = coalesc(element(self.*.public_ip, count.index), element(self.*.ipv6_address, count.index))
     user        = var.ssh_user
     private_key = file("${var.private_key_path}")
     timeout     = "300s"
@@ -125,11 +127,12 @@ resource "aws_instance" "bootstrap_node_evm" {
 }
 
 resource "aws_instance" "full_node" {
-  count             = length(var.aws_region) * var.full-node-config.instance-count
-  ami               = data.aws_ami.ubuntu_amd64.image_id
-  instance_type     = var.full-node-config.instance-type
-  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
-  availability_zone = var.azs
+  count              = length(var.aws_region) * var.full-node-config.instance-count
+  ami                = data.aws_ami.ubuntu_amd64.image_id
+  instance_type      = var.full-node-config.instance-type
+  subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone  = var.azs
+  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
@@ -178,7 +181,7 @@ resource "aws_instance" "full_node" {
   # Setting up the ssh connection
   connection {
     type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
+    host        = coalesc(element(self.*.public_ip, count.index), element(self.*.ipv6_address, count.index))
     user        = var.ssh_user
     private_key = file("${var.private_key_path}")
     timeout     = "300s"
@@ -188,11 +191,12 @@ resource "aws_instance" "full_node" {
 
 
 resource "aws_instance" "rpc_node" {
-  count             = length(var.aws_region) * var.rpc-node-config.instance-count
-  ami               = data.aws_ami.ubuntu_amd64.image_id
-  instance_type     = var.rpc-node-config.instance-type
-  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
-  availability_zone = var.azs
+  count              = length(var.aws_region) * var.rpc-node-config.instance-count
+  ami                = data.aws_ami.ubuntu_amd64.image_id
+  instance_type      = var.rpc-node-config.instance-type
+  subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone  = var.azs
+  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
@@ -241,7 +245,7 @@ resource "aws_instance" "rpc_node" {
   # Setting up the ssh connection
   connection {
     type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
+    host        = coalesc(element(self.*.public_ip, count.index), element(self.*.ipv6_address, count.index))
     user        = var.ssh_user
     private_key = file("${var.private_key_path}")
     timeout     = "300s"
@@ -251,11 +255,12 @@ resource "aws_instance" "rpc_node" {
 
 
 resource "aws_instance" "domain_node" {
-  count             = length(var.aws_region) * var.domain-node-config.instance-count
-  ami               = data.aws_ami.ubuntu_amd64.image_id
-  instance_type     = var.domain-node-config.instance-type
-  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
-  availability_zone = var.azs
+  count              = length(var.aws_region) * var.domain-node-config.instance-count
+  ami                = data.aws_ami.ubuntu_amd64.image_id
+  instance_type      = var.domain-node-config.instance-type
+  subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone  = var.azs
+  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
@@ -304,7 +309,7 @@ resource "aws_instance" "domain_node" {
   # Setting up the ssh connection
   connection {
     type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
+    host        = coalesc(element(self.*.public_ip, count.index), element(self.*.ipv6_address, count.index))
     user        = var.ssh_user
     private_key = file("${var.private_key_path}")
     timeout     = "300s"
@@ -314,11 +319,12 @@ resource "aws_instance" "domain_node" {
 
 
 resource "aws_instance" "farmer_node" {
-  count             = length(var.aws_region) * var.farmer-node-config.instance-count
-  ami               = data.aws_ami.ubuntu_amd64.image_id
-  instance_type     = var.farmer-node-config.instance-type
-  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
-  availability_zone = var.azs
+  count              = length(var.aws_region) * var.farmer-node-config.instance-count
+  ami                = data.aws_ami.ubuntu_amd64.image_id
+  instance_type      = var.farmer-node-config.instance-type
+  subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone  = var.azs
+  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
@@ -366,7 +372,7 @@ resource "aws_instance" "farmer_node" {
   # Setting up the ssh connection
   connection {
     type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
+    host        = coalesc(element(self.*.public_ip, count.index), element(self.*.ipv6_address, count.index))
     user        = var.ssh_user
     private_key = file("${var.private_key_path}")
     timeout     = "300s"

--- a/aws/network-primitives/network.tf
+++ b/aws/network-primitives/network.tf
@@ -1,7 +1,8 @@
 resource "aws_vpc" "network_vpc" {
-  cidr_block           = var.vpc_cidr_block
-  enable_dns_support   = true
-  enable_dns_hostnames = true
+  cidr_block                       = var.vpc_cidr_block
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  assign_generated_ipv6_cidr_block = true
 
   tags = {
     name = "${var.network_name}-vpc"
@@ -12,8 +13,9 @@ resource "aws_subnet" "public_subnets" {
   count                   = length(var.public_subnet_cidrs)
   vpc_id                  = aws_vpc.network_vpc.id
   cidr_block              = element(var.public_subnet_cidrs, count.index)
+  ipv6_cidr_block         = cidrsubnet(aws_vpc.network_vpc.ipv6_cidr_block, 8, count.index)
   availability_zone       = var.azs
-  map_public_ip_on_launch = "true"
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.network_name}-public-subnet-${count.index}"
@@ -69,93 +71,123 @@ resource "aws_security_group" "network_sg" {
   vpc_id      = aws_vpc.network_vpc.id
 
   ingress {
-    description = "HTTPS for VPC"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "HTTPS for VPC"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "HTTP for VPC"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "HTTP for VPC"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "SSH for VPC"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "SSH for VPC"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "Node Port 30333 for VPC"
-    from_port   = 30333
-    to_port     = 30333
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Node Port 30333 for VPC"
+    from_port        = 30333
+    to_port          = 30333
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "Node Port 30433 for VPC"
-    from_port   = 30433
-    to_port     = 30433
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Node Port 30433 for VPC"
+    from_port        = 30433
+    to_port          = 30433
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "Domain Operator Node Port 40333 for VPC"
-    from_port   = 40333
-    to_port     = 40333
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Node Port 30334 Domain port for VPC"
+    from_port        = 30334
+    to_port          = 30334
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "Farmer Port 30533 for VPC"
-    from_port   = 30533
-    to_port     = 30533
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Domain Operator Node Port 40333 for VPC"
+    from_port        = 40333
+    to_port          = 40333
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Farmer Port 30533 for VPC"
+    from_port        = 30533
+    to_port          = 30533
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   # UDP ports
 
   ingress {
-    description = "Node UDP Port 30333 for VPC"
-    from_port   = 30333
-    to_port     = 30333
-    protocol    = "udp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Node UDP Port 30333 for VPC"
+    from_port        = 30333
+    to_port          = 30333
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "Node UDP Port 30433 for VPC"
-    from_port   = 30433
-    to_port     = 30433
-    protocol    = "udp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Node UDP Port 30433 for VPC"
+    from_port        = 30433
+    to_port          = 30433
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "Farmer UDP Port 30533 for VPC"
-    from_port   = 30533
-    to_port     = 30533
-    protocol    = "udp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Node UDP Port 30334 Domain port for VPC"
+    from_port        = 30334
+    to_port          = 30334
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+
+  ingress {
+    description      = "Farmer UDP Port 30533 for VPC"
+    from_port        = 30533
+    to_port          = 30533
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {
-    description = "egress for VPC"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "egress for VPC"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {

--- a/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP_V6=`curl -s -6 https://ifconfig.me`
 
 reserved_only=${1}
 node_count=${2}
@@ -67,6 +68,10 @@ services:
       - /ip4/0.0.0.0/udp/30533/quic-v1
       - "--listen-on"
       - /ip4/0.0.0.0/tcp/30533
+      - "--listen-on"
+      - /ip6/::/udp/30533/quic-v1
+      - "--listen-on"
+      - /ip6/::/tcp/30533
       - --protocol-version
       - \${GENESIS_HASH}
       - "--in-peers"
@@ -82,6 +87,10 @@ services:
 #      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
 #      - "--external-address"
 #      - "/ip4/$EXTERNAL_IP/tcp/30533"
+#      - "--external-address"
+#      - "/ip6/$EXTERNAL_IP_V6/udp/30533/quic-v1"
+#      - "--external-address"
+#      - "/ip6/$EXTERNAL_IP_V6/tcp/30533"
 EOF
 
 for (( i = 0; i < node_count; i++ )); do
@@ -122,33 +131,32 @@ cat >> ~/subspace/docker-compose.yml << EOF
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip6/::/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/tcp/30433",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
-      "--in-peers-light", "1000",
       "--dsn-in-connections", "1000",
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 for (( i = 0; i < node_count; i++ )); do
   if [ "${current_node}" != "${i}" ]; then
     addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
     echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
   fi
 done
 

--- a/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/aws/network-primitives/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP_V6=`curl -s -6 https://ifconfig.me`
 
 reserved_only=${1}
 node_count=${2}
@@ -69,6 +70,10 @@ services:
       - /ip4/0.0.0.0/udp/30533/quic-v1
       - "--listen-on"
       - /ip4/0.0.0.0/tcp/30533
+      - "--listen-on"
+      - /ip6/::/udp/30533/quic-v1
+      - "--listen-on"
+      - /ip6/::/tcp/30533
       - --protocol-version
       - \${GENESIS_HASH}
       - "--in-peers"
@@ -83,6 +88,10 @@ services:
       - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
       - "--external-address"
       - "/ip4/$EXTERNAL_IP/tcp/30533"
+      - "--external-address"
+      - "/ip6/$EXTERNAL_IP_V6/udp/30533/quic-v1"
+      - "--external-address"
+      - "/ip6/$EXTERNAL_IP_V6/tcp/30533"
 EOF
 for (( i = 0; i < node_count; i++ )); do
   if [ "${current_node}" != "${i}" ]; then
@@ -105,23 +114,24 @@ cat >> ~/subspace/docker-compose.yml << EOF
       - "30333:30333/tcp"
       - "30433:30433/udp"
       - "30433:30433/tcp"
-      - "\${OPERATOR_PORT}:40333/tcp"
+      - "\${OPERATOR_PORT}:30334/tcp"
       - "9615:9615"
     logging:
       driver: loki
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip6/::/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/tcp/30433",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
@@ -130,15 +140,14 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_keys.txt)
     echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-    echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
@@ -155,22 +164,16 @@ if [ "${enable_domains}" == "true" ]; then
     {
     # core domain
       echo '      "--",'
-      echo '      "--chain=${NETWORK_NAME}",'
-      echo '      "--node-key", "${NODE_KEY}",'
-    #  echo '      "--enable-subspace-block-relay",'
+      echo '      "--domain-id", "${DOMAIN_ID}",'
       echo '      "--state-pruning", "archive",'
       echo '      "--blocks-pruning", "archive",'
-      echo '      "--listen-addr", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
-      echo '      "--domain-id=${DOMAIN_ID}",'
-      echo '      "--base-path", "/var/subspace/core_${DOMAIN_LABEL}_domain",'
+      echo '      "--listen-on", "/ip4/0.0.0.0/tcp/${OPERATOR_PORT}",'
       echo '      "--rpc-cors", "all",'
-      echo '      "--rpc-port", "8944",'
-      echo '      "--unsafe-rpc-external",'
-      echo '      "--relayer-id=${RELAYER_DOMAIN_ID}",'
+      echo '      "--rpc-listen-on", "0.0.0.0:8944",'
     for (( i = 0; i <  node_count; i++ )); do
       addr=$(sed -nr "s/NODE_${i}_OPERATOR_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
       echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-      echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
     done
 
     }  >> ~/subspace/docker-compose.yml

--- a/aws/network-primitives/scripts/create_full_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_full_node_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP_V6=`curl -s -6 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
@@ -57,16 +58,17 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "256",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/::/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/tcp/30433",
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "1000",
       "--out-peers", "1000",
@@ -74,10 +76,8 @@ services:
       "--dsn-out-connections", "1000",
       "--dsn-pending-in-connections", "1000",
       "--dsn-pending-out-connections", "1000",
-      "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 reserved_only=${1}
@@ -89,7 +89,7 @@ dsn_bootstrap_node_count=${4}
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 # // TODO: make configurable with gemini network as it's not needed for devnet

--- a/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
+++ b/aws/network-primitives/scripts/create_rpc_node_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP_V6=`curl -s -6 https://ifconfig.me`
 
 cat > ~/subspace/docker-compose.yml << EOF
 version: "3.7"
@@ -96,25 +97,25 @@ services:
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command: [
+      "run",
       "--chain", "\${NETWORK_NAME}",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
-#      "--enable-subspace-block-relay",
       "--state-pruning", "archive",
       "--blocks-pruning", "archive",
-      "--listen-addr", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--listen-on", "/ip6/::/tcp/30333",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
       "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
-#      "--piece-cache-size", "\${PIECE_CACHE_SIZE}",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/tcp/30433",
       "--node-key", "\${NODE_KEY}",
-      "--rpc-cors", "all",
-      "--rpc-external",
       "--in-peers", "500",
       "--out-peers", "250",
-      "--in-peers-light", "500",
       "--rpc-max-connections", "10000",
-      "--prometheus-port", "9615",
-      "--prometheus-external",
+      "--rpc-cors", "all",
+      "--rpc-listen-on", "0.0.0.0:9944",
+      "--rpc-methods", "safe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 
 reserved_only=${1}
@@ -126,7 +127,7 @@ dsn_bootstrap_node_count=${4}
 for (( i = 0; i < bootstrap_node_count; i++ )); do
   addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
-  echo "      \"--bootnodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done
 
 # // TODO: make configurable with gemini network as it's not needed for devnet


### PR DESCRIPTION
The PR adds IPv6 support to the AWS VPC, subnets, route tables and VM instances. The subspace network configuration is also configured to listen on IPv6 to improve support/connectivity to the network.

closes #239 