### PR TITLE
add reusable AWS module

### DIFF
--- a/templates/terraform/aws/ec2/ami.tf
+++ b/templates/terraform/aws/ec2/ami.tf
@@ -1,0 +1,20 @@
+data "aws_ami" "ubuntu_amd64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["099720109477"]
+}

--- a/templates/terraform/aws/ec2/main.tf
+++ b/templates/terraform/aws/ec2/main.tf
@@ -1,0 +1,422 @@
+data "aws_partition" "current" {}
+
+locals {
+  create = var.create
+
+  is_t_instance_type = can(regex("t[0-9]+\\.[a-z0-9]+", var.instance_type))
+
+  ami = try(coalesce(data.aws_ami.ubuntu_amd64.image_id, try(nonsensitive(data.aws_ssm_parameter.this[0].value), null)), null)
+}
+
+data "aws_ssm_parameter" "this" {
+  count = local.create && var.ami == null ? 1 : 0
+
+  name = var.ami_ssm_parameter
+}
+
+######################################
+# Instance
+######################################
+
+resource "aws_instance" "this" {
+  count = local.create && var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
+
+  ami                  = local.ami
+  instance_type        = var.instance_type
+
+  user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
+  user_data_replace_on_change = var.user_data_replace_on_change
+
+  availability_zone      = var.availability_zone
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  key_name             = var.key_name
+  monitoring           = var.monitoring
+  get_password_data    = var.get_password_data
+  iam_instance_profile = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].name : var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  secondary_private_ips       = var.secondary_private_ips
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
+
+    content {
+      capacity_reservation_preference = try(capacity_reservation_specification.value.capacity_reservation_preference, null)
+
+      dynamic "capacity_reservation_target" {
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
+
+        content {
+          capacity_reservation_id                 = try(capacity_reservation_target.value.capacity_reservation_id, null)
+          capacity_reservation_resource_group_arn = try(capacity_reservation_target.value.capacity_reservation_resource_group_arn, null)
+        }
+      }
+    }
+  }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+
+    content {
+      delete_on_termination = try(root_block_device.value.delete_on_termination, null)
+      encrypted             = try(root_block_device.value.encrypted, null)
+      iops                  = try(root_block_device.value.iops, null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = try(root_block_device.value.volume_size, null)
+      volume_type           = try(root_block_device.value.volume_type, null)
+      throughput            = try(root_block_device.value.throughput, null)
+      tags                  = try(root_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+
+    content {
+      delete_on_termination = try(ebs_block_device.value.delete_on_termination, null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = try(ebs_block_device.value.encrypted, null)
+      iops                  = try(ebs_block_device.value.iops, null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = try(ebs_block_device.value.volume_size, null)
+      volume_type           = try(ebs_block_device.value.volume_type, null)
+      throughput            = try(ebs_block_device.value.throughput, null)
+      tags                  = try(ebs_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = try(ephemeral_block_device.value.no_device, null)
+      virtual_name = try(ephemeral_block_device.value.virtual_name, null)
+    }
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, "enabled")
+      http_tokens                 = try(metadata_options.value.http_tokens, "optional")
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, 1)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = try(network_interface.value.delete_on_termination, false)
+    }
+  }
+
+  dynamic "private_dns_name_options" {
+    for_each = length(var.private_dns_name_options) > 0 ? [var.private_dns_name_options] : []
+
+    content {
+      hostname_type                        = try(private_dns_name_options.value.hostname_type, null)
+      enable_resource_name_dns_a_record    = try(private_dns_name_options.value.enable_resource_name_dns_a_record, null)
+      enable_resource_name_dns_aaaa_record = try(private_dns_name_options.value.enable_resource_name_dns_aaaa_record, null)
+    }
+  }
+
+  dynamic "launch_template" {
+    for_each = length(var.launch_template) > 0 ? [var.launch_template] : []
+
+    content {
+      id      = lookup(var.launch_template, "id", null)
+      name    = lookup(var.launch_template, "name", null)
+      version = lookup(var.launch_template, "version", null)
+    }
+  }
+
+  dynamic "maintenance_options" {
+    for_each = length(var.maintenance_options) > 0 ? [var.maintenance_options] : []
+
+    content {
+      auto_recovery = try(maintenance_options.value.auto_recovery, null)
+    }
+  }
+
+  enclave_options {
+    enabled = var.enclave_options_enabled
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  disable_api_stop                     = var.disable_api_stop
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+  host_id                              = var.host_id
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+
+  timeouts {
+    create = try(var.timeouts.create, null)
+    update = try(var.timeouts.update, null)
+    delete = try(var.timeouts.delete, null)
+  }
+
+  tags        = merge({ "Name" = var.name }, var.instance_tags, var.tags)
+  volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
+
+  lifecycle {
+
+    ignore_changes = [ami, ipv6_address_count]
+
+  }
+}
+
+
+######################################
+# Spot Instance
+######################################
+
+resource "aws_spot_instance_request" "this" {
+  count = local.create && var.create_spot_instance ? 1 : 0
+
+  ami                  = data.aws_ami.ubuntu_amd64.image_id
+  instance_type        = var.instance_type
+
+  user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
+  user_data_replace_on_change = var.user_data_replace_on_change
+
+  availability_zone      = var.availability_zone
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  key_name             = var.key_name
+  monitoring           = var.monitoring
+  get_password_data    = var.get_password_data
+  iam_instance_profile = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].name : var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  secondary_private_ips       = var.secondary_private_ips
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  # Spot request specific attributes
+  spot_price                     = var.spot_price
+  wait_for_fulfillment           = var.spot_wait_for_fulfillment
+  spot_type                      = var.spot_type
+  launch_group                   = var.spot_launch_group
+  block_duration_minutes         = var.spot_block_duration_minutes
+  instance_interruption_behavior = var.spot_instance_interruption_behavior
+  valid_until                    = var.spot_valid_until
+  valid_from                     = var.spot_valid_from
+  # End spot request specific attributes
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
+
+    content {
+      capacity_reservation_preference = try(capacity_reservation_specification.value.capacity_reservation_preference, null)
+
+      dynamic "capacity_reservation_target" {
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
+        content {
+          capacity_reservation_id                 = try(capacity_reservation_target.value.capacity_reservation_id, null)
+          capacity_reservation_resource_group_arn = try(capacity_reservation_target.value.capacity_reservation_resource_group_arn, null)
+        }
+      }
+    }
+  }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+
+    content {
+      delete_on_termination = try(root_block_device.value.delete_on_termination, null)
+      encrypted             = try(root_block_device.value.encrypted, null)
+      iops                  = try(root_block_device.value.iops, null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = try(root_block_device.value.volume_size, null)
+      volume_type           = try(root_block_device.value.volume_type, null)
+      throughput            = try(root_block_device.value.throughput, null)
+      tags                  = try(root_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+
+    content {
+      delete_on_termination = try(ebs_block_device.value.delete_on_termination, null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = try(ebs_block_device.value.encrypted, null)
+      iops                  = try(ebs_block_device.value.iops, null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = try(ebs_block_device.value.volume_size, null)
+      volume_type           = try(ebs_block_device.value.volume_type, null)
+      throughput            = try(ebs_block_device.value.throughput, null)
+      tags                  = try(ebs_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = try(ephemeral_block_device.value.no_device, null)
+      virtual_name = try(ephemeral_block_device.value.virtual_name, null)
+    }
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, "enabled")
+      http_tokens                 = try(metadata_options.value.http_tokens, "optional")
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, 1)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = try(network_interface.value.delete_on_termination, false)
+    }
+  }
+
+  dynamic "launch_template" {
+    for_each = length(var.launch_template) > 0 ? [var.launch_template] : []
+
+    content {
+      id      = lookup(var.launch_template, "id", null)
+      name    = lookup(var.launch_template, "name", null)
+      version = lookup(var.launch_template, "version", null)
+    }
+  }
+
+  enclave_options {
+    enabled = var.enclave_options_enabled
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+  host_id                              = var.host_id
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+
+  timeouts {
+    create = try(var.timeouts.create, null)
+    delete = try(var.timeouts.delete, null)
+  }
+
+  tags        = merge({ "Name" = var.name }, var.instance_tags, var.tags)
+  volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
+}
+
+######################################
+# IAM Role / Instance Profile
+######################################
+
+locals {
+  iam_role_name = try(coalesce(var.iam_role_name, var.name), "")
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  count = var.create && var.create_iam_instance_profile ? 1 : 0
+
+  statement {
+    sid     = "EC2AssumeRole"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = var.create && var.create_iam_instance_profile ? 1 : 0
+
+  name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  path        = var.iam_role_path
+  description = var.iam_role_description
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role_policy[0].json
+  permissions_boundary  = var.iam_role_permissions_boundary
+  force_detach_policies = true
+
+  tags = merge(var.tags, var.iam_role_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = { for k, v in var.iam_role_policies : k => v if var.create && var.create_iam_instance_profile }
+
+  policy_arn = each.value
+  role       = aws_iam_role.this[0].name
+}
+
+resource "aws_iam_instance_profile" "this" {
+  count = var.create && var.create_iam_instance_profile ? 1 : 0
+
+  role = aws_iam_role.this[0].name
+
+  name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  path        = var.iam_role_path
+
+  tags = merge(var.tags, var.iam_role_tags)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/templates/terraform/aws/ec2/outputs.tf
+++ b/templates/terraform/aws/ec2/outputs.tf
@@ -1,0 +1,231 @@
+output "id" {
+    description = "The ID of the instance"
+    value = try(
+      aws_instance.this[0].id,
+      aws_instance.ignore_ami[0].id,
+      aws_spot_instance_request.this[0].id,
+      null,
+    )
+  }
+
+  output "arn" {
+    description = "The ARN of the instance"
+    value = try(
+      aws_instance.this[0].arn,
+      aws_instance.ignore_ami[0].arn,
+      aws_spot_instance_request.this[0].arn,
+      null,
+    )
+  }
+
+  output "capacity_reservation_specification" {
+    description = "Capacity reservation specification of the instance"
+    value = try(
+      aws_instance.this[0].capacity_reservation_specification,
+      aws_instance.ignore_ami[0].capacity_reservation_specification,
+      aws_spot_instance_request.this[0].capacity_reservation_specification,
+      null,
+    )
+  }
+
+  output "instance_state" {
+    description = "The state of the instance"
+    value = try(
+      aws_instance.this[0].instance_state,
+      aws_instance.ignore_ami[0].instance_state,
+      aws_spot_instance_request.this[0].instance_state,
+      null,
+    )
+  }
+
+  output "outpost_arn" {
+    description = "The ARN of the Outpost the instance is assigned to"
+    value = try(
+      aws_instance.this[0].outpost_arn,
+      aws_instance.ignore_ami[0].outpost_arn,
+      aws_spot_instance_request.this[0].outpost_arn,
+      null,
+    )
+  }
+
+  output "password_data" {
+    description = "Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true"
+    value = try(
+      aws_instance.this[0].password_data,
+      aws_instance.ignore_ami[0].password_data,
+      aws_spot_instance_request.this[0].password_data,
+      null,
+    )
+  }
+
+  output "primary_network_interface_id" {
+    description = "The ID of the instance's primary network interface"
+    value = try(
+      aws_instance.this[0].primary_network_interface_id,
+      aws_instance.ignore_ami[0].primary_network_interface_id,
+      aws_spot_instance_request.this[0].primary_network_interface_id,
+      null,
+    )
+  }
+
+  output "private_dns" {
+    description = "The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
+    value = try(
+      aws_instance.this[0].private_dns,
+      aws_instance.ignore_ami[0].private_dns,
+      aws_spot_instance_request.this[0].private_dns,
+      null,
+    )
+  }
+
+  output "public_dns" {
+    description = "The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
+    value = try(
+      aws_instance.this[0].public_dns,
+      aws_instance.ignore_ami[0].public_dns,
+      aws_spot_instance_request.this[0].public_dns,
+      null,
+    )
+  }
+
+  output "public_ip" {
+    description = "The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached"
+    value = try(
+      aws_instance.this[0].public_ip,
+      aws_instance.ignore_ami[0].public_ip,
+      aws_spot_instance_request.this[0].public_ip,
+      null,
+    )
+  }
+
+  output "private_ip" {
+    description = "The private IP address assigned to the instance"
+    value = try(
+      aws_instance.this[0].private_ip,
+      aws_instance.ignore_ami[0].private_ip,
+      aws_spot_instance_request.this[0].private_ip,
+      null,
+    )
+  }
+
+  output "ipv6_addresses" {
+    description = "The IPv6 address assigned to the instance, if applicable"
+    value = try(
+      aws_instance.this[0].ipv6_addresses,
+      aws_instance.ignore_ami[0].ipv6_addresses,
+      aws_spot_instance_request.this[0].ipv6_addresses,
+      [],
+    )
+  }
+
+  output "tags_all" {
+    description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block"
+    value = try(
+      aws_instance.this[0].tags_all,
+      aws_instance.ignore_ami[0].tags_all,
+      aws_spot_instance_request.this[0].tags_all,
+      {},
+    )
+  }
+
+  output "spot_bid_status" {
+    description = "The current bid status of the Spot Instance Request"
+    value       = try(aws_spot_instance_request.this[0].spot_bid_status, null)
+  }
+
+  output "spot_request_state" {
+    description = "The current request state of the Spot Instance Request"
+    value       = try(aws_spot_instance_request.this[0].spot_request_state, null)
+  }
+
+  output "spot_instance_id" {
+    description = "The Instance ID (if any) that is currently fulfilling the Spot Instance request"
+    value       = try(aws_spot_instance_request.this[0].spot_instance_id, null)
+  }
+
+  output "ami" {
+    description = "AMI ID that was used to create the instance"
+    value = try(
+      aws_instance.this[0].ami,
+      aws_instance.ignore_ami[0].ami,
+      aws_spot_instance_request.this[0].ami,
+      null,
+    )
+  }
+
+  output "availability_zone" {
+    description = "The availability zone of the created instance"
+    value = try(
+      aws_instance.this[0].availability_zone,
+      aws_instance.ignore_ami[0].availability_zone,
+      aws_spot_instance_request.this[0].availability_zone,
+      null,
+    )
+  }
+
+  ######################################
+  # IAM Role / Instance Profile
+  ######################################
+
+  output "iam_role_name" {
+    description = "The name of the IAM role"
+    value       = try(aws_iam_role.this[0].name, null)
+  }
+
+  output "iam_role_arn" {
+    description = "The Amazon Resource Name (ARN) specifying the IAM role"
+    value       = try(aws_iam_role.this[0].arn, null)
+  }
+
+  output "iam_role_unique_id" {
+    description = "Stable and unique string identifying the IAM role"
+    value       = try(aws_iam_role.this[0].unique_id, null)
+  }
+
+  output "iam_instance_profile_arn" {
+    description = "ARN assigned by AWS to the instance profile"
+    value       = try(aws_iam_instance_profile.this[0].arn, null)
+  }
+
+  output "iam_instance_profile_id" {
+    description = "Instance profile's ID"
+    value       = try(aws_iam_instance_profile.this[0].id, null)
+  }
+
+  output "iam_instance_profile_unique" {
+    description = "Stable and unique string identifying the IAM instance profile"
+    value       = try(aws_iam_instance_profile.this[0].unique_id, null)
+  }
+
+  ######################################
+  # Block Devices
+  ######################################
+  output "root_block_device" {
+    description = "Root block device information"
+    value = try(
+      aws_instance.this[0].root_block_device,
+      aws_instance.ignore_ami[0].root_block_device,
+      aws_spot_instance_request.this[0].root_block_device,
+      null
+    )
+  }
+
+  output "ebs_block_device" {
+    description = "EBS block device information"
+    value = try(
+      aws_instance.this[0].ebs_block_device,
+      aws_instance.ignore_ami[0].ebs_block_device,
+      aws_spot_instance_request.this[0].ebs_block_device,
+      null
+    )
+  }
+
+  output "ephemeral_block_device" {
+    description = "Ephemeral block device information"
+    value = try(
+      aws_instance.this[0].ephemeral_block_device,
+      aws_instance.ignore_ami[0].ephemeral_block_device,
+      aws_spot_instance_request.this[0].ephemeral_block_device,
+      null
+    )
+  }

--- a/templates/terraform/aws/ec2/variables.tf
+++ b/templates/terraform/aws/ec2/variables.tf
@@ -1,0 +1,404 @@
+variable "create" {
+    description = "Whether to create an instance"
+    type        = bool
+    default     = true
+  }
+
+  variable "name" {
+    description = "Name to be used on EC2 instance created"
+    type        = string
+    default     = ""
+  }
+
+  variable "ami_ssm_parameter" {
+    description = "SSM parameter name for the AMI ID. For Amazon Linux AMI SSM parameters see [reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html)"
+    type        = string
+    default     = "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+  }
+
+  variable "ami" {
+    description = "ID of AMI to use for the instance"
+    type        = string
+    default     = null
+  }
+
+  variable "ignore_ami_changes" {
+    description = "Whether changes to the AMI ID changes should be ignored by Terraform. Note - changing this value will result in the replacement of the instance"
+    type        = bool
+    default     = true
+  }
+
+  variable "associate_public_ip_address" {
+    description = "Whether to associate a public IP address with an instance in a VPC"
+    type        = bool
+    default     = null
+  }
+
+  variable "maintenance_options" {
+    description = "The maintenance options for the instance"
+    type        = any
+    default     = {}
+  }
+
+  variable "availability_zone" {
+    description = "AZ to start the instance in"
+    type        = string
+    default     = null
+  }
+
+  variable "capacity_reservation_specification" {
+    description = "Describes an instance's Capacity Reservation targeting option"
+    type        = any
+    default     = {}
+  }
+
+  variable "cpu_credits" {
+    description = "The credit option for CPU usage (unlimited or standard)"
+    type        = string
+    default     = null
+  }
+
+  variable "disable_api_termination" {
+    description = "If true, enables EC2 Instance Termination Protection"
+    type        = bool
+    default     = null
+  }
+
+  variable "ebs_block_device" {
+    description = "Additional EBS block devices to attach to the instance"
+    type        = list(any)
+    default     = []
+  }
+
+  variable "ebs_optimized" {
+    description = "If true, the launched EC2 instance will be EBS-optimized"
+    type        = bool
+    default     = null
+  }
+
+  variable "enclave_options_enabled" {
+    description = "Whether Nitro Enclaves will be enabled on the instance. Defaults to `false`"
+    type        = bool
+    default     = null
+  }
+
+  variable "ephemeral_block_device" {
+    description = "Customize Ephemeral (also known as Instance Store) volumes on the instance"
+    type        = list(map(string))
+    default     = []
+  }
+
+  variable "get_password_data" {
+    description = "If true, wait for password data to become available and retrieve it"
+    type        = bool
+    default     = null
+  }
+
+  variable "host_id" {
+    description = "ID of a dedicated host that the instance will be assigned to. Use when an instance is to be launched on a specific dedicated host"
+    type        = string
+    default     = null
+  }
+
+  variable "iam_instance_profile" {
+    description = "IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile"
+    type        = string
+    default     = null
+  }
+
+  variable "instance_initiated_shutdown_behavior" {
+    description = "Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance" # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior
+    type        = string
+    default     = null
+  }
+
+  variable "instance_type" {
+    description = "The type of instance to start"
+    type        = string
+    default     = "t3.micro"
+  }
+
+  variable "instance_tags" {
+    description = "Additional tags for the instance"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "ipv6_address_count" {
+    description = "A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet"
+    type        = number
+    default     = null
+  }
+
+  variable "ipv6_addresses" {
+    description = "Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface"
+    type        = list(string)
+    default     = null
+  }
+
+  variable "key_name" {
+    description = "Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource"
+    type        = string
+    default     = null
+  }
+
+  variable "launch_template" {
+    description = "Specifies a Launch Template to configure the instance. Parameters configured on this resource will override the corresponding parameters in the Launch Template"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "metadata_options" {
+    description = "Customize the metadata options of the instance"
+    type        = map(string)
+    default = {
+      "http_endpoint"               = "enabled"
+      "http_put_response_hop_limit" = 1
+      "http_tokens"                 = "optional"
+    }
+  }
+
+  variable "monitoring" {
+    description = "If true, the launched EC2 instance will have detailed monitoring enabled"
+    type        = bool
+    default     = null
+  }
+
+  variable "network_interface" {
+    description = "Customize network interfaces to be attached at instance boot time"
+    type        = list(map(string))
+    default     = []
+  }
+
+  variable "private_dns_name_options" {
+    description = "Customize the private DNS name options of the instance"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "placement_group" {
+    description = "The Placement Group to start the instance in"
+    type        = string
+    default     = null
+  }
+
+  variable "private_ip" {
+    description = "Private IP address to associate with the instance in a VPC"
+    type        = string
+    default     = null
+  }
+
+  variable "root_block_device" {
+    description = "Customize details about the root block device of the instance. See Block Devices below for details"
+    type        = list(any)
+    default     = []
+  }
+
+  variable "secondary_private_ips" {
+    description = "A list of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e. referenced in a `network_interface block`"
+    type        = list(string)
+    default     = null
+  }
+
+  variable "source_dest_check" {
+    description = "Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs"
+    type        = bool
+    default     = null
+  }
+
+  variable "subnet_id" {
+    description = "The VPC Subnet ID to launch in"
+    type        = string
+    default     = null
+  }
+
+  variable "tags" {
+    description = "A mapping of tags to assign to the resource"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "tenancy" {
+    description = "The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host"
+    type        = string
+    default     = null
+  }
+
+  variable "user_data" {
+    description = "The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user_data_base64 instead"
+    type        = string
+    default     = null
+  }
+
+  variable "user_data_base64" {
+    description = "Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption"
+    type        = string
+    default     = null
+  }
+
+  variable "user_data_replace_on_change" {
+    description = "When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set"
+    type        = bool
+    default     = null
+  }
+
+  variable "volume_tags" {
+    description = "A mapping of tags to assign to the devices created by the instance at launch time"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "enable_volume_tags" {
+    description = "Whether to enable volume tags (if enabled it conflicts with root_block_device tags)"
+    type        = bool
+    default     = true
+  }
+
+  variable "vpc_security_group_ids" {
+    description = "A list of security group IDs to associate with"
+    type        = list(string)
+    default     = null
+  }
+
+  variable "timeouts" {
+    description = "Define maximum timeout for creating, updating, and deleting EC2 instance resources"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "cpu_options" {
+    description = "Defines CPU options to apply to the instance at launch time."
+    type        = any
+    default     = {}
+  }
+
+  variable "cpu_core_count" {
+    description = "Sets the number of CPU cores for an instance" # This option is only supported on creation of instance type that support CPU Options https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#cpu-options-supported-instances-values
+    type        = number
+    default     = null
+  }
+
+  variable "cpu_threads_per_core" {
+    description = "Sets the number of CPU threads per core for an instance (has no effect unless cpu_core_count is also set)"
+    type        = number
+    default     = null
+  }
+
+  # Spot instance request
+  variable "create_spot_instance" {
+    description = "Depicts if the instance is a spot instance"
+    type        = bool
+    default     = false
+  }
+
+  variable "spot_price" {
+    description = "The maximum price to request on the spot market. Defaults to on-demand price"
+    type        = string
+    default     = null
+  }
+
+  variable "spot_wait_for_fulfillment" {
+    description = "If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached"
+    type        = bool
+    default     = null
+  }
+
+  variable "spot_type" {
+    description = "If set to one-time, after the instance is terminated, the spot request will be closed. Default `persistent`"
+    type        = string
+    default     = null
+  }
+
+  variable "spot_launch_group" {
+    description = "A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually"
+    type        = string
+    default     = null
+  }
+
+  variable "spot_block_duration_minutes" {
+    description = "The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360)"
+    type        = number
+    default     = null
+  }
+
+  variable "spot_instance_interruption_behavior" {
+    description = "Indicates Spot instance behavior when it is interrupted. Valid values are `terminate`, `stop`, or `hibernate`"
+    type        = string
+    default     = null
+  }
+
+  variable "spot_valid_until" {
+    description = "The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+    type        = string
+    default     = null
+  }
+
+  variable "spot_valid_from" {
+    description = "The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+    type        = string
+    default     = null
+  }
+
+  variable "disable_api_stop" {
+    description = "If true, enables EC2 Instance Stop Protection"
+    type        = bool
+    default     = null
+
+  }
+  variable "putin_khuylo" {
+    description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
+    type        = bool
+    default     = true
+  }
+
+  ######################################
+  # IAM Role / Instance Profile
+  ######################################
+
+  variable "create_iam_instance_profile" {
+    description = "Determines whether an IAM instance profile is created or to use an existing IAM instance profile"
+    type        = bool
+    default     = false
+  }
+
+  variable "iam_role_name" {
+    description = "Name to use on IAM role created"
+    type        = string
+    default     = null
+  }
+
+  variable "iam_role_use_name_prefix" {
+    description = "Determines whether the IAM role name (`iam_role_name` or `name`) is used as a prefix"
+    type        = bool
+    default     = true
+  }
+
+  variable "iam_role_path" {
+    description = "IAM role path"
+    type        = string
+    default     = null
+  }
+
+  variable "iam_role_description" {
+    description = "Description of the role"
+    type        = string
+    default     = null
+  }
+
+  variable "iam_role_permissions_boundary" {
+    description = "ARN of the policy that is used to set the permissions boundary for the IAM role"
+    type        = string
+    default     = null
+  }
+
+  variable "iam_role_policies" {
+    description = "Policies attached to the IAM role"
+    type        = map(string)
+    default     = {}
+  }
+
+  variable "iam_role_tags" {
+    description = "A map of additional tags to add to the IAM role/profile created"
+    type        = map(string)
+    default     = {}
+  }

--- a/templates/terraform/aws/ec2/versions.tf
+++ b/templates/terraform/aws/ec2/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+    required_version = ">= 1.5.7"
+
+    required_providers {
+      aws = {
+        source  = "hashicorp/aws"
+        version = ">= 5.20"
+      }
+    }
+  }

--- a/templates/terraform/aws/vpc/main.tf
+++ b/templates/terraform/aws/vpc/main.tf
@@ -1,0 +1,593 @@
+locals {
+    len_public_subnets      = max(length(var.public_subnets), length(var.public_subnet_ipv6_prefixes))
+    len_private_subnets     = max(length(var.private_subnets), length(var.private_subnet_ipv6_prefixes))
+
+
+    max_subnet_length = max(
+      local.len_private_subnets,
+      local.len_public_subnets,
+    )
+
+    # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
+    vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
+
+    create_vpc = var.create_vpc
+  }
+
+  ######################################
+  # VPC
+  ######################################
+
+  resource "aws_vpc" "this" {
+    count = local.create_vpc ? 1 : 0
+
+    cidr_block          = var.use_ipam_pool ? null : var.cidr
+    ipv4_ipam_pool_id   = var.ipv4_ipam_pool_id
+    ipv4_netmask_length = var.ipv4_netmask_length
+
+    assign_generated_ipv6_cidr_block     = var.enable_ipv6 && !var.use_ipam_pool ? true : null
+    ipv6_cidr_block                      = var.ipv6_cidr
+    ipv6_ipam_pool_id                    = var.ipv6_ipam_pool_id
+    ipv6_netmask_length                  = var.ipv6_netmask_length
+    ipv6_cidr_block_network_border_group = var.ipv6_cidr_block_network_border_group
+
+    instance_tenancy                     = var.instance_tenancy
+    enable_dns_hostnames                 = var.enable_dns_hostnames
+    enable_dns_support                   = var.enable_dns_support
+    enable_network_address_usage_metrics = var.enable_network_address_usage_metrics
+
+    tags = merge(
+      { "Name" = var.name },
+      var.tags,
+      var.vpc_tags,
+    )
+  }
+
+  resource "aws_vpc_ipv4_cidr_block_association" "this" {
+    count = local.create_vpc && length(var.secondary_cidr_blocks) > 0 ? length(var.secondary_cidr_blocks) : 0
+
+    # Do not turn this into `local.vpc_id`
+    vpc_id = aws_vpc.this[0].id
+
+    cidr_block = element(var.secondary_cidr_blocks, count.index)
+  }
+
+  ######################################
+  # DHCP Options Set
+  ######################################
+
+  resource "aws_vpc_dhcp_options" "this" {
+    count = local.create_vpc && var.enable_dhcp_options ? 1 : 0
+
+    domain_name          = var.dhcp_options_domain_name
+    domain_name_servers  = var.dhcp_options_domain_name_servers
+    ntp_servers          = var.dhcp_options_ntp_servers
+    netbios_name_servers = var.dhcp_options_netbios_name_servers
+    netbios_node_type    = var.dhcp_options_netbios_node_type
+
+    tags = merge(
+      { "Name" = var.name },
+      var.tags,
+      var.dhcp_options_tags,
+    )
+  }
+
+  resource "aws_vpc_dhcp_options_association" "this" {
+    count = local.create_vpc && var.enable_dhcp_options ? 1 : 0
+
+    vpc_id          = local.vpc_id
+    dhcp_options_id = aws_vpc_dhcp_options.this[0].id
+  }
+
+  ######################################
+  # Public Subnets
+  ######################################
+
+  locals {
+    create_public_subnets = local.create_vpc && local.len_public_subnets > 0
+  }
+
+  resource "aws_subnet" "public" {
+    count = local.create_public_subnets && (!var.one_nat_gateway_per_az || local.len_public_subnets >= length(var.azs)) ? local.len_public_subnets : 0
+
+    assign_ipv6_address_on_creation                = var.enable_ipv6 && var.public_subnet_ipv6_native ? true : var.public_subnet_assign_ipv6_address_on_creation
+    availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+    availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+    cidr_block                                     = var.public_subnet_ipv6_native ? null : element(concat(var.public_subnets, [""]), count.index)
+    enable_dns64                                   = var.enable_ipv6 && var.public_subnet_enable_dns64
+    enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.public_subnet_enable_resource_name_dns_aaaa_record_on_launch
+    enable_resource_name_dns_a_record_on_launch    = !var.public_subnet_ipv6_native && var.public_subnet_enable_resource_name_dns_a_record_on_launch
+    ipv6_cidr_block                                = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.public_subnet_ipv6_prefixes[count.index]) : null
+    ipv6_native                                    = var.enable_ipv6 && var.public_subnet_ipv6_native
+    map_public_ip_on_launch                        = var.map_public_ip_on_launch
+    private_dns_hostname_type_on_launch            = var.public_subnet_private_dns_hostname_type_on_launch
+    vpc_id                                         = local.vpc_id
+
+    tags = merge(
+      {
+        Name = try(
+          var.public_subnet_names[count.index],
+          format("${var.name}-${var.public_subnet_suffix}-%s", element(var.azs, count.index))
+        )
+      },
+      var.tags,
+      var.public_subnet_tags,
+      lookup(var.public_subnet_tags_per_az, element(var.azs, count.index), {})
+    )
+  }
+
+  resource "aws_route_table" "public" {
+    count = local.create_public_subnets ? 1 : 0
+
+    vpc_id = local.vpc_id
+
+    tags = merge(
+      { "Name" = "${var.name}-${var.public_subnet_suffix}" },
+      var.tags,
+      var.public_route_table_tags,
+    )
+  }
+
+  resource "aws_route_table_association" "public" {
+    count = local.create_public_subnets ? local.len_public_subnets : 0
+
+    subnet_id      = element(aws_subnet.public[*].id, count.index)
+    route_table_id = aws_route_table.public[0].id
+  }
+
+  resource "aws_route" "public_internet_gateway" {
+    count = local.create_public_subnets && var.create_igw ? 1 : 0
+
+    route_table_id         = aws_route_table.public[0].id
+    destination_cidr_block = "0.0.0.0/0"
+    gateway_id             = aws_internet_gateway.this[0].id
+
+    timeouts {
+      create = "5m"
+    }
+  }
+
+  resource "aws_route" "public_internet_gateway_ipv6" {
+    count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? 1 : 0
+
+    route_table_id              = aws_route_table.public[0].id
+    destination_ipv6_cidr_block = "::/0"
+    gateway_id                  = aws_internet_gateway.this[0].id
+  }
+
+  ######################################
+  # Public Network ACLs
+  ######################################
+
+  resource "aws_network_acl" "public" {
+    count = local.create_public_subnets && var.public_dedicated_network_acl ? 1 : 0
+
+    vpc_id     = local.vpc_id
+    subnet_ids = aws_subnet.public[*].id
+
+    tags = merge(
+      { "Name" = "${var.name}-${var.public_subnet_suffix}" },
+      var.tags,
+      var.public_acl_tags,
+    )
+  }
+
+  resource "aws_network_acl_rule" "public_inbound" {
+    count = local.create_public_subnets && var.public_dedicated_network_acl ? length(var.public_inbound_acl_rules) : 0
+
+    network_acl_id = aws_network_acl.public[0].id
+
+    egress          = false
+    rule_number     = var.public_inbound_acl_rules[count.index]["rule_number"]
+    rule_action     = var.public_inbound_acl_rules[count.index]["rule_action"]
+    from_port       = lookup(var.public_inbound_acl_rules[count.index], "from_port", null)
+    to_port         = lookup(var.public_inbound_acl_rules[count.index], "to_port", null)
+    icmp_code       = lookup(var.public_inbound_acl_rules[count.index], "icmp_code", null)
+    icmp_type       = lookup(var.public_inbound_acl_rules[count.index], "icmp_type", null)
+    protocol        = var.public_inbound_acl_rules[count.index]["protocol"]
+    cidr_block      = lookup(var.public_inbound_acl_rules[count.index], "cidr_block", null)
+    ipv6_cidr_block = lookup(var.public_inbound_acl_rules[count.index], "ipv6_cidr_block", null)
+  }
+
+  resource "aws_network_acl_rule" "public_outbound" {
+    count = local.create_public_subnets && var.public_dedicated_network_acl ? length(var.public_outbound_acl_rules) : 0
+
+    network_acl_id = aws_network_acl.public[0].id
+
+    egress          = true
+    rule_number     = var.public_outbound_acl_rules[count.index]["rule_number"]
+    rule_action     = var.public_outbound_acl_rules[count.index]["rule_action"]
+    from_port       = lookup(var.public_outbound_acl_rules[count.index], "from_port", null)
+    to_port         = lookup(var.public_outbound_acl_rules[count.index], "to_port", null)
+    icmp_code       = lookup(var.public_outbound_acl_rules[count.index], "icmp_code", null)
+    icmp_type       = lookup(var.public_outbound_acl_rules[count.index], "icmp_type", null)
+    protocol        = var.public_outbound_acl_rules[count.index]["protocol"]
+    cidr_block      = lookup(var.public_outbound_acl_rules[count.index], "cidr_block", null)
+    ipv6_cidr_block = lookup(var.public_outbound_acl_rules[count.index], "ipv6_cidr_block", null)
+  }
+
+  ######################################
+  # Private Subnets
+  ######################################
+
+  locals {
+    create_private_subnets = local.create_vpc && local.len_private_subnets > 0
+  }
+
+  resource "aws_subnet" "private" {
+    count = local.create_private_subnets ? local.len_private_subnets : 0
+
+    assign_ipv6_address_on_creation                = var.enable_ipv6 && var.private_subnet_ipv6_native ? true : var.private_subnet_assign_ipv6_address_on_creation
+    availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+    availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+    cidr_block                                     = var.private_subnet_ipv6_native ? null : element(concat(var.private_subnets, [""]), count.index)
+    enable_dns64                                   = var.enable_ipv6 && var.private_subnet_enable_dns64
+    enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.private_subnet_enable_resource_name_dns_aaaa_record_on_launch
+    enable_resource_name_dns_a_record_on_launch    = !var.private_subnet_ipv6_native && var.private_subnet_enable_resource_name_dns_a_record_on_launch
+    ipv6_cidr_block                                = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.private_subnet_ipv6_prefixes[count.index]) : null
+    ipv6_native                                    = var.enable_ipv6 && var.private_subnet_ipv6_native
+    private_dns_hostname_type_on_launch            = var.private_subnet_private_dns_hostname_type_on_launch
+    vpc_id                                         = local.vpc_id
+
+    tags = merge(
+      {
+        Name = try(
+          var.private_subnet_names[count.index],
+          format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
+        )
+      },
+      var.tags,
+      var.private_subnet_tags,
+      lookup(var.private_subnet_tags_per_az, element(var.azs, count.index), {})
+    )
+  }
+
+  # There are as many routing tables as the number of NAT gateways
+  resource "aws_route_table" "private" {
+    count = local.create_private_subnets && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
+
+    vpc_id = local.vpc_id
+
+    tags = merge(
+      {
+        "Name" = var.single_nat_gateway ? "${var.name}-${var.private_subnet_suffix}" : format(
+          "${var.name}-${var.private_subnet_suffix}-%s",
+          element(var.azs, count.index),
+        )
+      },
+      var.tags,
+      var.private_route_table_tags,
+    )
+  }
+
+  resource "aws_route_table_association" "private" {
+    count = local.create_private_subnets ? local.len_private_subnets : 0
+
+    subnet_id = element(aws_subnet.private[*].id, count.index)
+    route_table_id = element(
+      aws_route_table.private[*].id,
+      var.single_nat_gateway ? 0 : count.index,
+    )
+  }
+
+  ######################################
+  # Private Network ACLs
+  ######################################
+
+  locals {
+    create_private_network_acl = local.create_private_subnets && var.private_dedicated_network_acl
+  }
+
+  resource "aws_network_acl" "private" {
+    count = local.create_private_network_acl ? 1 : 0
+
+    vpc_id     = local.vpc_id
+    subnet_ids = aws_subnet.private[*].id
+
+    tags = merge(
+      { "Name" = "${var.name}-${var.private_subnet_suffix}" },
+      var.tags,
+      var.private_acl_tags,
+    )
+  }
+
+  resource "aws_network_acl_rule" "private_inbound" {
+    count = local.create_private_network_acl ? length(var.private_inbound_acl_rules) : 0
+
+    network_acl_id = aws_network_acl.private[0].id
+
+    egress          = false
+    rule_number     = var.private_inbound_acl_rules[count.index]["rule_number"]
+    rule_action     = var.private_inbound_acl_rules[count.index]["rule_action"]
+    from_port       = lookup(var.private_inbound_acl_rules[count.index], "from_port", null)
+    to_port         = lookup(var.private_inbound_acl_rules[count.index], "to_port", null)
+    icmp_code       = lookup(var.private_inbound_acl_rules[count.index], "icmp_code", null)
+    icmp_type       = lookup(var.private_inbound_acl_rules[count.index], "icmp_type", null)
+    protocol        = var.private_inbound_acl_rules[count.index]["protocol"]
+    cidr_block      = lookup(var.private_inbound_acl_rules[count.index], "cidr_block", null)
+    ipv6_cidr_block = lookup(var.private_inbound_acl_rules[count.index], "ipv6_cidr_block", null)
+  }
+
+  resource "aws_network_acl_rule" "private_outbound" {
+    count = local.create_private_network_acl ? length(var.private_outbound_acl_rules) : 0
+
+    network_acl_id = aws_network_acl.private[0].id
+
+    egress          = true
+    rule_number     = var.private_outbound_acl_rules[count.index]["rule_number"]
+    rule_action     = var.private_outbound_acl_rules[count.index]["rule_action"]
+    from_port       = lookup(var.private_outbound_acl_rules[count.index], "from_port", null)
+    to_port         = lookup(var.private_outbound_acl_rules[count.index], "to_port", null)
+    icmp_code       = lookup(var.private_outbound_acl_rules[count.index], "icmp_code", null)
+    icmp_type       = lookup(var.private_outbound_acl_rules[count.index], "icmp_type", null)
+    protocol        = var.private_outbound_acl_rules[count.index]["protocol"]
+    cidr_block      = lookup(var.private_outbound_acl_rules[count.index], "cidr_block", null)
+    ipv6_cidr_block = lookup(var.private_outbound_acl_rules[count.index], "ipv6_cidr_block", null)
+  }
+
+  ######################################
+  # Internet Gateway
+  ######################################
+
+  resource "aws_internet_gateway" "this" {
+    count = local.create_public_subnets && var.create_igw ? 1 : 0
+
+    vpc_id = local.vpc_id
+
+    tags = merge(
+      { "Name" = var.name },
+      var.tags,
+      var.igw_tags,
+    )
+  }
+
+  resource "aws_egress_only_internet_gateway" "this" {
+    count = local.create_vpc && var.create_egress_only_igw && var.enable_ipv6 && local.max_subnet_length > 0 ? 1 : 0
+
+    vpc_id = local.vpc_id
+
+    tags = merge(
+      { "Name" = var.name },
+      var.tags,
+      var.igw_tags,
+    )
+  }
+
+  resource "aws_route" "private_ipv6_egress" {
+    count = local.create_vpc && var.create_egress_only_igw && var.enable_ipv6 ? local.len_private_subnets : 0
+
+    route_table_id              = element(aws_route_table.private[*].id, count.index)
+    destination_ipv6_cidr_block = "::/0"
+    egress_only_gateway_id      = element(aws_egress_only_internet_gateway.this[*].id, 0)
+  }
+
+  ######################################
+  # NAT Gateway
+  ######################################
+
+  locals {
+    nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length
+    nat_gateway_ips   = var.reuse_nat_ips ? var.external_nat_ip_ids : try(aws_eip.nat[*].id, [])
+  }
+
+  resource "aws_eip" "nat" {
+    count = local.create_vpc && var.enable_nat_gateway && !var.reuse_nat_ips ? local.nat_gateway_count : 0
+
+    domain = "vpc"
+
+    tags = merge(
+      {
+        "Name" = format(
+          "${var.name}-%s",
+          element(var.azs, var.single_nat_gateway ? 0 : count.index),
+        )
+      },
+      var.tags,
+      var.nat_eip_tags,
+    )
+
+    depends_on = [aws_internet_gateway.this]
+  }
+
+  resource "aws_nat_gateway" "this" {
+    count = local.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0
+
+    allocation_id = element(
+      local.nat_gateway_ips,
+      var.single_nat_gateway ? 0 : count.index,
+    )
+    subnet_id = element(
+      aws_subnet.public[*].id,
+      var.single_nat_gateway ? 0 : count.index,
+    )
+
+    tags = merge(
+      {
+        "Name" = format(
+          "${var.name}-%s",
+          element(var.azs, var.single_nat_gateway ? 0 : count.index),
+        )
+      },
+      var.tags,
+      var.nat_gateway_tags,
+    )
+
+    depends_on = [aws_internet_gateway.this]
+  }
+
+  resource "aws_route" "private_nat_gateway" {
+    count = local.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0
+
+    route_table_id         = element(aws_route_table.private[*].id, count.index)
+    destination_cidr_block = var.nat_gateway_destination_cidr_block
+    nat_gateway_id         = element(aws_nat_gateway.this[*].id, count.index)
+
+    timeouts {
+      create = "5m"
+    }
+  }
+
+  resource "aws_route" "private_dns64_nat_gateway" {
+    count = local.create_vpc && var.enable_nat_gateway && var.enable_ipv6 && var.private_subnet_enable_dns64 ? local.nat_gateway_count : 0
+
+    route_table_id              = element(aws_route_table.private[*].id, count.index)
+    destination_ipv6_cidr_block = "64:ff9b::/96"
+    nat_gateway_id              = element(aws_nat_gateway.this[*].id, count.index)
+
+    timeouts {
+      create = "5m"
+    }
+  }
+
+  ######################################
+  # Default VPC
+  ######################################
+
+  resource "aws_default_vpc" "this" {
+    count = var.manage_default_vpc ? 1 : 0
+
+    enable_dns_support   = var.default_vpc_enable_dns_support
+    enable_dns_hostnames = var.default_vpc_enable_dns_hostnames
+
+    tags = merge(
+      { "Name" = coalesce(var.default_vpc_name, "default") },
+      var.tags,
+      var.default_vpc_tags,
+    )
+  }
+
+  resource "aws_default_security_group" "this" {
+    count = local.create_vpc && var.manage_default_security_group ? 1 : 0
+
+    vpc_id = aws_vpc.this[0].id
+
+    dynamic "ingress" {
+      for_each = var.default_security_group_ingress
+      content {
+        self             = lookup(ingress.value, "self", null)
+        cidr_blocks      = compact(split(",", lookup(ingress.value, "cidr_blocks", "")))
+        ipv6_cidr_blocks = compact(split(",", lookup(ingress.value, "ipv6_cidr_blocks", "")))
+        prefix_list_ids  = compact(split(",", lookup(ingress.value, "prefix_list_ids", "")))
+        security_groups  = compact(split(",", lookup(ingress.value, "security_groups", "")))
+        description      = lookup(ingress.value, "description", null)
+        from_port        = lookup(ingress.value, "from_port", 0)
+        to_port          = lookup(ingress.value, "to_port", 0)
+        protocol         = lookup(ingress.value, "protocol", "-1")
+      }
+    }
+
+    dynamic "egress" {
+      for_each = var.default_security_group_egress
+      content {
+        self             = lookup(egress.value, "self", null)
+        cidr_blocks      = compact(split(",", lookup(egress.value, "cidr_blocks", "")))
+        ipv6_cidr_blocks = compact(split(",", lookup(egress.value, "ipv6_cidr_blocks", "")))
+        prefix_list_ids  = compact(split(",", lookup(egress.value, "prefix_list_ids", "")))
+        security_groups  = compact(split(",", lookup(egress.value, "security_groups", "")))
+        description      = lookup(egress.value, "description", null)
+        from_port        = lookup(egress.value, "from_port", 0)
+        to_port          = lookup(egress.value, "to_port", 0)
+        protocol         = lookup(egress.value, "protocol", "-1")
+      }
+    }
+
+    tags = merge(
+      { "Name" = coalesce(var.default_security_group_name, "${var.name}-default") },
+      var.tags,
+      var.default_security_group_tags,
+    )
+  }
+
+  ######################################
+  # Default Network ACLs
+  ######################################
+
+  resource "aws_default_network_acl" "this" {
+    count = local.create_vpc && var.manage_default_network_acl ? 1 : 0
+
+    default_network_acl_id = aws_vpc.this[0].default_network_acl_id
+
+    # subnet_ids is using lifecycle ignore_changes, so it is not necessary to list
+    # any explicitly. See https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/736
+    subnet_ids = null
+
+    dynamic "ingress" {
+      for_each = var.default_network_acl_ingress
+      content {
+        action          = ingress.value.action
+        cidr_block      = lookup(ingress.value, "cidr_block", null)
+        from_port       = ingress.value.from_port
+        icmp_code       = lookup(ingress.value, "icmp_code", null)
+        icmp_type       = lookup(ingress.value, "icmp_type", null)
+        ipv6_cidr_block = lookup(ingress.value, "ipv6_cidr_block", null)
+        protocol        = ingress.value.protocol
+        rule_no         = ingress.value.rule_no
+        to_port         = ingress.value.to_port
+      }
+    }
+    dynamic "egress" {
+      for_each = var.default_network_acl_egress
+      content {
+        action          = egress.value.action
+        cidr_block      = lookup(egress.value, "cidr_block", null)
+        from_port       = egress.value.from_port
+        icmp_code       = lookup(egress.value, "icmp_code", null)
+        icmp_type       = lookup(egress.value, "icmp_type", null)
+        ipv6_cidr_block = lookup(egress.value, "ipv6_cidr_block", null)
+        protocol        = egress.value.protocol
+        rule_no         = egress.value.rule_no
+        to_port         = egress.value.to_port
+      }
+    }
+
+    tags = merge(
+      { "Name" = coalesce(var.default_network_acl_name, "${var.name}-default") },
+      var.tags,
+      var.default_network_acl_tags,
+    )
+
+    lifecycle {
+      ignore_changes = [subnet_ids]
+    }
+  }
+
+  ######################################
+  # Default Route
+  ######################################
+
+  resource "aws_default_route_table" "default" {
+    count = local.create_vpc && var.manage_default_route_table ? 1 : 0
+
+    default_route_table_id = aws_vpc.this[0].default_route_table_id
+    propagating_vgws       = var.default_route_table_propagating_vgws
+
+    dynamic "route" {
+      for_each = var.default_route_table_routes
+      content {
+        # One of the following destinations must be provided
+        cidr_block      = route.value.cidr_block
+        ipv6_cidr_block = lookup(route.value, "ipv6_cidr_block", null)
+
+        # One of the following targets must be provided
+        egress_only_gateway_id    = lookup(route.value, "egress_only_gateway_id", null)
+        gateway_id                = lookup(route.value, "gateway_id", null)
+        instance_id               = lookup(route.value, "instance_id", null)
+        nat_gateway_id            = lookup(route.value, "nat_gateway_id", null)
+        network_interface_id      = lookup(route.value, "network_interface_id", null)
+        transit_gateway_id        = lookup(route.value, "transit_gateway_id", null)
+        vpc_endpoint_id           = lookup(route.value, "vpc_endpoint_id", null)
+        vpc_peering_connection_id = lookup(route.value, "vpc_peering_connection_id", null)
+      }
+    }
+
+    timeouts {
+      create = "5m"
+      update = "5m"
+    }
+
+    tags = merge(
+      { "Name" = coalesce(var.default_route_table_name, "${var.name}-default") },
+      var.tags,
+      var.default_route_table_tags,
+    )
+  }

--- a/templates/terraform/aws/vpc/outputs.tf
+++ b/templates/terraform/aws/vpc/outputs.tf
@@ -1,0 +1,310 @@
+locals {
+    public_route_table_ids   = aws_route_table.public[*].id
+    private_route_table_ids  = aws_route_table.private[*].id
+  }
+
+  ######################################
+  # VPC
+  ######################################
+
+  output "vpc_id" {
+    description = "The ID of the VPC"
+    value       = try(aws_vpc.this[0].id, null)
+  }
+
+  output "vpc_arn" {
+    description = "The ARN of the VPC"
+    value       = try(aws_vpc.this[0].arn, null)
+  }
+
+  output "vpc_cidr_block" {
+    description = "The CIDR block of the VPC"
+    value       = try(aws_vpc.this[0].cidr_block, null)
+  }
+
+  output "default_security_group_id" {
+    description = "The ID of the security group created by default on VPC creation"
+    value       = try(aws_vpc.this[0].default_security_group_id, null)
+  }
+
+  output "default_network_acl_id" {
+    description = "The ID of the default network ACL"
+    value       = try(aws_vpc.this[0].default_network_acl_id, null)
+  }
+
+  output "default_route_table_id" {
+    description = "The ID of the default route table"
+    value       = try(aws_vpc.this[0].default_route_table_id, null)
+  }
+
+  output "vpc_instance_tenancy" {
+    description = "Tenancy of instances spin up within VPC"
+    value       = try(aws_vpc.this[0].instance_tenancy, null)
+  }
+
+  output "vpc_enable_dns_support" {
+    description = "Whether or not the VPC has DNS support"
+    value       = try(aws_vpc.this[0].enable_dns_support, null)
+  }
+
+  output "vpc_enable_dns_hostnames" {
+    description = "Whether or not the VPC has DNS hostname support"
+    value       = try(aws_vpc.this[0].enable_dns_hostnames, null)
+  }
+
+  output "vpc_main_route_table_id" {
+    description = "The ID of the main route table associated with this VPC"
+    value       = try(aws_vpc.this[0].main_route_table_id, null)
+  }
+
+  output "vpc_ipv6_association_id" {
+    description = "The association ID for the IPv6 CIDR block"
+    value       = try(aws_vpc.this[0].ipv6_association_id, null)
+  }
+
+  output "vpc_ipv6_cidr_block" {
+    description = "The IPv6 CIDR block"
+    value       = try(aws_vpc.this[0].ipv6_cidr_block, null)
+  }
+
+  output "vpc_secondary_cidr_blocks" {
+    description = "List of secondary CIDR blocks of the VPC"
+    value       = compact(aws_vpc_ipv4_cidr_block_association.this[*].cidr_block)
+  }
+
+  output "vpc_owner_id" {
+    description = "The ID of the AWS account that owns the VPC"
+    value       = try(aws_vpc.this[0].owner_id, null)
+  }
+
+  ######################################
+  # DHCP Options Set
+  ######################################
+
+  output "dhcp_options_id" {
+    description = "The ID of the DHCP options"
+    value       = try(aws_vpc_dhcp_options.this[0].id, null)
+  }
+
+  ######################################
+  # Internet Gateway
+  ######################################
+
+  output "igw_id" {
+    description = "The ID of the Internet Gateway"
+    value       = try(aws_internet_gateway.this[0].id, null)
+  }
+
+  output "igw_arn" {
+    description = "The ARN of the Internet Gateway"
+    value       = try(aws_internet_gateway.this[0].arn, null)
+  }
+
+  ######################################
+  # Public Subnets
+  ######################################
+
+  output "public_subnets" {
+    description = "List of IDs of public subnets"
+    value       = aws_subnet.public[*].id
+  }
+
+  output "public_subnet_arns" {
+    description = "List of ARNs of public subnets"
+    value       = aws_subnet.public[*].arn
+  }
+
+  output "public_subnets_cidr_blocks" {
+    description = "List of cidr_blocks of public subnets"
+    value       = compact(aws_subnet.public[*].cidr_block)
+  }
+
+  output "public_subnets_ipv6_cidr_blocks" {
+    description = "List of IPv6 cidr_blocks of public subnets in an IPv6 enabled VPC"
+    value       = compact(aws_subnet.public[*].ipv6_cidr_block)
+  }
+
+  output "public_route_table_ids" {
+    description = "List of IDs of public route tables"
+    value       = local.public_route_table_ids
+  }
+
+  output "public_internet_gateway_route_id" {
+    description = "ID of the internet gateway route"
+    value       = try(aws_route.public_internet_gateway[0].id, null)
+  }
+
+  output "public_internet_gateway_ipv6_route_id" {
+    description = "ID of the IPv6 internet gateway route"
+    value       = try(aws_route.public_internet_gateway_ipv6[0].id, null)
+  }
+
+  output "public_route_table_association_ids" {
+    description = "List of IDs of the public route table association"
+    value       = aws_route_table_association.public[*].id
+  }
+
+  output "public_network_acl_id" {
+    description = "ID of the public network ACL"
+    value       = try(aws_network_acl.public[0].id, null)
+  }
+
+  output "public_network_acl_arn" {
+    description = "ARN of the public network ACL"
+    value       = try(aws_network_acl.public[0].arn, null)
+  }
+
+  ######################################
+  # Private Subnets
+  ######################################
+
+  output "private_subnets" {
+    description = "List of IDs of private subnets"
+    value       = aws_subnet.private[*].id
+  }
+
+  output "private_subnet_arns" {
+    description = "List of ARNs of private subnets"
+    value       = aws_subnet.private[*].arn
+  }
+
+  output "private_subnets_cidr_blocks" {
+    description = "List of cidr_blocks of private subnets"
+    value       = compact(aws_subnet.private[*].cidr_block)
+  }
+
+  output "private_subnets_ipv6_cidr_blocks" {
+    description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
+    value       = compact(aws_subnet.private[*].ipv6_cidr_block)
+  }
+
+  output "private_route_table_ids" {
+    description = "List of IDs of private route tables"
+    value       = local.private_route_table_ids
+  }
+
+  output "private_nat_gateway_route_ids" {
+    description = "List of IDs of the private nat gateway route"
+    value       = aws_route.private_nat_gateway[*].id
+  }
+
+  output "private_ipv6_egress_route_ids" {
+    description = "List of IDs of the ipv6 egress route"
+    value       = aws_route.private_ipv6_egress[*].id
+  }
+
+  output "private_route_table_association_ids" {
+    description = "List of IDs of the private route table association"
+    value       = aws_route_table_association.private[*].id
+  }
+
+  output "private_network_acl_id" {
+    description = "ID of the private network ACL"
+    value       = try(aws_network_acl.private[0].id, null)
+  }
+
+  output "private_network_acl_arn" {
+    description = "ARN of the private network ACL"
+    value       = try(aws_network_acl.private[0].arn, null)
+  }
+
+  ######################################
+  # NAT Gateway
+  ######################################
+
+  output "nat_ids" {
+    description = "List of allocation ID of Elastic IPs created for AWS NAT Gateway"
+    value       = aws_eip.nat[*].id
+  }
+
+  output "nat_public_ips" {
+    description = "List of public Elastic IPs created for AWS NAT Gateway"
+    value       = var.reuse_nat_ips ? var.external_nat_ips : aws_eip.nat[*].public_ip
+  }
+
+  output "natgw_ids" {
+    description = "List of NAT Gateway IDs"
+    value       = aws_nat_gateway.this[*].id
+  }
+
+  output "natgw_interface_ids" {
+    description = "List of Network Interface IDs assigned to NAT Gateways"
+    value       = aws_nat_gateway.this[*].network_interface_id
+  }
+
+  ######################################
+  # Egress Only Gateway
+  ######################################
+
+  output "egress_only_internet_gateway_id" {
+    description = "The ID of the egress only Internet Gateway"
+    value       = try(aws_egress_only_internet_gateway.this[0].id, null)
+  }
+
+  ######################################
+  # Default VPC
+  ######################################
+
+  output "default_vpc_id" {
+    description = "The ID of the Default VPC"
+    value       = try(aws_default_vpc.this[0].id, null)
+  }
+
+  output "default_vpc_arn" {
+    description = "The ARN of the Default VPC"
+    value       = try(aws_default_vpc.this[0].arn, null)
+  }
+
+  output "default_vpc_cidr_block" {
+    description = "The CIDR block of the Default VPC"
+    value       = try(aws_default_vpc.this[0].cidr_block, null)
+  }
+
+  output "default_vpc_default_security_group_id" {
+    description = "The ID of the security group created by default on Default VPC creation"
+    value       = try(aws_default_vpc.this[0].default_security_group_id, null)
+  }
+
+  output "default_vpc_default_network_acl_id" {
+    description = "The ID of the default network ACL of the Default VPC"
+    value       = try(aws_default_vpc.this[0].default_network_acl_id, null)
+  }
+
+  output "default_vpc_default_route_table_id" {
+    description = "The ID of the default route table of the Default VPC"
+    value       = try(aws_default_vpc.this[0].default_route_table_id, null)
+  }
+
+  output "default_vpc_instance_tenancy" {
+    description = "Tenancy of instances spin up within Default VPC"
+    value       = try(aws_default_vpc.this[0].instance_tenancy, null)
+  }
+
+  output "default_vpc_enable_dns_support" {
+    description = "Whether or not the Default VPC has DNS support"
+    value       = try(aws_default_vpc.this[0].enable_dns_support, null)
+  }
+
+  output "default_vpc_enable_dns_hostnames" {
+    description = "Whether or not the Default VPC has DNS hostname support"
+    value       = try(aws_default_vpc.this[0].enable_dns_hostnames, null)
+  }
+
+  output "default_vpc_main_route_table_id" {
+    description = "The ID of the main route table associated with the Default VPC"
+    value       = try(aws_default_vpc.this[0].main_route_table_id, null)
+  }
+
+  ######################################
+  # Static values
+  ######################################
+
+  output "azs" {
+    description = "A list of availability zones specified as argument to this module"
+    value       = var.azs
+  }
+
+  output "name" {
+    description = "The name of the VPC specified as argument to this module"
+    value       = var.name
+  }

--- a/templates/terraform/aws/vpc/variables.tf
+++ b/templates/terraform/aws/vpc/variables.tf
@@ -1,0 +1,672 @@
+######################################
+# VPC
+######################################
+
+variable "create_vpc" {
+  description = "Controls if VPC should be created (it affects almost all resources)"
+  type        = bool
+  default     = true
+}
+
+variable "name" {
+  description = "Name to be used on all the resources as identifier"
+  type        = string
+  default     = ""
+}
+
+variable "cidr" {
+  description = "(Optional) The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv4_netmask_length` & `ipv4_ipam_pool_id`"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "secondary_cidr_blocks" {
+  description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
+  type        = list(string)
+  default     = []
+}
+
+variable "instance_tenancy" {
+  description = "A tenancy option for instances launched into the VPC"
+  type        = string
+  default     = "default"
+}
+
+variable "azs" {
+  description = "A list of availability zones names or ids in the region"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_network_address_usage_metrics" {
+  description = "Determines whether network address usage metrics are enabled for the VPC"
+  type        = bool
+  default     = null
+}
+
+variable "use_ipam_pool" {
+  description = "Determines whether IPAM pool is used for CIDR allocation"
+  type        = bool
+  default     = false
+}
+
+variable "ipv4_ipam_pool_id" {
+  description = "(Optional) The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR"
+  type        = string
+  default     = null
+}
+
+variable "ipv4_netmask_length" {
+  description = "(Optional) The netmask length of the IPv4 CIDR you want to allocate to this VPC. Requires specifying a ipv4_ipam_pool_id"
+  type        = number
+  default     = null
+}
+
+variable "enable_ipv6" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block"
+  type        = bool
+  default     = false
+}
+
+variable "ipv6_cidr" {
+  description = "(Optional) IPv6 CIDR block to request from an IPAM Pool. Can be set explicitly or derived from IPAM using `ipv6_netmask_length`"
+  type        = string
+  default     = null
+}
+
+variable "ipv6_ipam_pool_id" {
+  description = "(Optional) IPAM Pool ID for a IPv6 pool. Conflicts with `assign_generated_ipv6_cidr_block`"
+  type        = string
+  default     = null
+}
+
+variable "ipv6_netmask_length" {
+  description = "(Optional) Netmask length to request from IPAM Pool. Conflicts with `ipv6_cidr_block`. This can be omitted if IPAM pool as a `allocation_default_netmask_length` set. Valid values: `56`"
+  type        = number
+  default     = null
+}
+
+variable "ipv6_cidr_block_network_border_group" {
+  description = "By default when an IPv6 CIDR is assigned to a VPC a default ipv6_cidr_block_network_border_group will be set to the region of the VPC. This can be changed to restrict advertisement of public addresses to specific Network Border Groups such as LocalZones"
+  type        = string
+  default     = null
+}
+
+variable "vpc_tags" {
+  description = "Additional tags for the VPC"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# DHCP Options Set
+######################################
+
+variable "enable_dhcp_options" {
+  description = "Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type"
+  type        = bool
+  default     = false
+}
+
+variable "dhcp_options_domain_name" {
+  description = "Specifies DNS name for DHCP options set (requires enable_dhcp_options set to true)"
+  type        = string
+  default     = ""
+}
+
+variable "dhcp_options_domain_name_servers" {
+  description = "Specify a list of DNS server addresses for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true)"
+  type        = list(string)
+  default     = ["AmazonProvidedDNS"]
+}
+
+variable "dhcp_options_ntp_servers" {
+  description = "Specify a list of NTP servers for DHCP options set (requires enable_dhcp_options set to true)"
+  type        = list(string)
+  default     = []
+}
+
+variable "dhcp_options_netbios_name_servers" {
+  description = "Specify a list of netbios servers for DHCP options set (requires enable_dhcp_options set to true)"
+  type        = list(string)
+  default     = []
+}
+
+variable "dhcp_options_netbios_node_type" {
+  description = "Specify netbios node_type for DHCP options set (requires enable_dhcp_options set to true)"
+  type        = string
+  default     = ""
+}
+
+variable "dhcp_options_tags" {
+  description = "Additional tags for the DHCP option set (requires enable_dhcp_options set to true)"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Public Subnets
+######################################
+
+variable "public_subnets" {
+  description = "A list of public subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnet_assign_ipv6_address_on_creation" {
+  description = "Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`"
+  type        = bool
+  default     = false
+}
+
+variable "public_subnet_enable_dns64" {
+  description = "Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. Default: `true`"
+  type        = bool
+  default     = true
+}
+
+variable "public_subnet_enable_resource_name_dns_aaaa_record_on_launch" {
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records. Default: `true`"
+  type        = bool
+  default     = true
+}
+
+variable "public_subnet_enable_resource_name_dns_a_record_on_launch" {
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS A records. Default: `false`"
+  type        = bool
+  default     = false
+}
+
+variable "public_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnet_ipv6_native" {
+  description = "Indicates whether to create an IPv6-only subnet. Default: `false`"
+  type        = bool
+  default     = false
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default is `false`"
+  type        = bool
+  default     = false
+}
+
+variable "public_subnet_private_dns_hostname_type_on_launch" {
+  description = "The type of hostnames to assign to instances in the subnet at launch. For IPv6-only subnets, an instance DNS name must be based on the instance ID. For dual-stack and IPv4-only subnets, you can specify whether DNS names use the instance IPv4 address or the instance ID. Valid values: `ip-name`, `resource-name`"
+  type        = string
+  default     = null
+}
+
+variable "public_subnet_names" {
+  description = "Explicit values to use in the Name tag on public subnets. If empty, Name tags are generated"
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnet_suffix" {
+  description = "Suffix to append to public subnets name"
+  type        = string
+  default     = "public"
+}
+
+variable "public_subnet_tags" {
+  description = "Additional tags for the public subnets"
+  type        = map(string)
+  default     = {}
+}
+
+variable "public_subnet_tags_per_az" {
+  description = "Additional tags for the public subnets where the primary key is the AZ"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "public_route_table_tags" {
+  description = "Additional tags for the public route tables"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Public Network ACLs
+######################################
+
+variable "public_dedicated_network_acl" {
+  description = "Whether to use dedicated network ACL (not default) and custom rules for public subnets"
+  type        = bool
+  default     = false
+}
+
+variable "public_inbound_acl_rules" {
+  description = "Public subnets inbound network ACLs"
+  type        = list(map(string))
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "public_outbound_acl_rules" {
+  description = "Public subnets outbound network ACLs"
+  type        = list(map(string))
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "public_acl_tags" {
+  description = "Additional tags for the public subnets network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Private Subnets
+######################################
+
+variable "private_subnets" {
+  description = "A list of private subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_assign_ipv6_address_on_creation" {
+  description = "Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`"
+  type        = bool
+  default     = false
+}
+
+variable "private_subnet_enable_dns64" {
+  description = "Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. Default: `true`"
+  type        = bool
+  default     = true
+}
+
+variable "private_subnet_enable_resource_name_dns_aaaa_record_on_launch" {
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records. Default: `true`"
+  type        = bool
+  default     = true
+}
+
+variable "private_subnet_enable_resource_name_dns_a_record_on_launch" {
+  description = "Indicates whether to respond to DNS queries for instance hostnames with DNS A records. Default: `false`"
+  type        = bool
+  default     = false
+}
+
+variable "private_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_ipv6_native" {
+  description = "Indicates whether to create an IPv6-only subnet. Default: `false`"
+  type        = bool
+  default     = false
+}
+
+variable "private_subnet_private_dns_hostname_type_on_launch" {
+  description = "The type of hostnames to assign to instances in the subnet at launch. For IPv6-only subnets, an instance DNS name must be based on the instance ID. For dual-stack and IPv4-only subnets, you can specify whether DNS names use the instance IPv4 address or the instance ID. Valid values: `ip-name`, `resource-name`"
+  type        = string
+  default     = null
+}
+
+variable "private_subnet_names" {
+  description = "Explicit values to use in the Name tag on private subnets. If empty, Name tags are generated"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_suffix" {
+  description = "Suffix to append to private subnets name"
+  type        = string
+  default     = "private"
+}
+
+variable "private_subnet_tags" {
+  description = "Additional tags for the private subnets"
+  type        = map(string)
+  default     = {}
+}
+
+variable "private_subnet_tags_per_az" {
+  description = "Additional tags for the private subnets where the primary key is the AZ"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "private_route_table_tags" {
+  description = "Additional tags for the private route tables"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Private Network ACLs
+######################################
+
+variable "private_dedicated_network_acl" {
+  description = "Whether to use dedicated network ACL (not default) and custom rules for private subnets"
+  type        = bool
+  default     = false
+}
+
+variable "private_inbound_acl_rules" {
+  description = "Private subnets inbound network ACLs"
+  type        = list(map(string))
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "private_outbound_acl_rules" {
+  description = "Private subnets outbound network ACLs"
+  type        = list(map(string))
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "private_acl_tags" {
+  description = "Additional tags for the private subnets network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+
+######################################
+# Internet Gateway
+######################################
+
+variable "create_igw" {
+  description = "Controls if an Internet Gateway is created for public subnets and the related routes that connect them"
+  type        = bool
+  default     = true
+}
+
+variable "create_egress_only_igw" {
+  description = "Controls if an Egress Only Internet Gateway is created and its related routes"
+  type        = bool
+  default     = true
+}
+
+variable "igw_tags" {
+  description = "Additional tags for the internet gateway"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# NAT Gateway
+######################################
+
+variable "enable_nat_gateway" {
+  description = "Should be true if you want to provision NAT Gateways for each of your private networks"
+  type        = bool
+  default     = false
+}
+
+variable "nat_gateway_destination_cidr_block" {
+  description = "Used to pass a custom destination route for private NAT Gateway. If not specified, the default 0.0.0.0/0 is used as a destination route"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "single_nat_gateway" {
+  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  type        = bool
+  default     = false
+}
+
+variable "one_nat_gateway_per_az" {
+  description = "Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`"
+  type        = bool
+  default     = false
+}
+
+variable "reuse_nat_ips" {
+  description = "Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable"
+  type        = bool
+  default     = false
+}
+
+variable "external_nat_ip_ids" {
+  description = "List of EIP IDs to be assigned to the NAT Gateways (used in combination with reuse_nat_ips)"
+  type        = list(string)
+  default     = []
+}
+
+variable "external_nat_ips" {
+  description = "List of EIPs to be used for `nat_public_ips` output (used in combination with reuse_nat_ips and external_nat_ip_ids)"
+  type        = list(string)
+  default     = []
+}
+
+variable "nat_gateway_tags" {
+  description = "Additional tags for the NAT gateways"
+  type        = map(string)
+  default     = {}
+}
+
+variable "nat_eip_tags" {
+  description = "Additional tags for the NAT EIP"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Default VPC
+######################################
+
+variable "manage_default_vpc" {
+  description = "Should be true to adopt and manage Default VPC"
+  type        = bool
+  default     = false
+}
+
+variable "default_vpc_name" {
+  description = "Name to be used on the Default VPC"
+  type        = string
+  default     = null
+}
+
+variable "default_vpc_enable_dns_support" {
+  description = "Should be true to enable DNS support in the Default VPC"
+  type        = bool
+  default     = true
+}
+
+variable "default_vpc_enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the Default VPC"
+  type        = bool
+  default     = true
+}
+
+variable "default_vpc_tags" {
+  description = "Additional tags for the Default VPC"
+  type        = map(string)
+  default     = {}
+}
+
+variable "manage_default_security_group" {
+  description = "Should be true to adopt and manage default security group"
+  type        = bool
+  default     = true
+}
+
+variable "default_security_group_name" {
+  description = "Name to be used on the default security group"
+  type        = string
+  default     = null
+}
+
+variable "default_security_group_ingress" {
+  description = "List of maps of ingress rules to set on the default security group"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "default_security_group_egress" {
+  description = "List of maps of egress rules to set on the default security group"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "default_security_group_tags" {
+  description = "Additional tags for the default security group"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Default Network ACLs
+######################################
+
+variable "manage_default_network_acl" {
+  description = "Should be true to adopt and manage Default Network ACL"
+  type        = bool
+  default     = true
+}
+
+variable "default_network_acl_name" {
+  description = "Name to be used on the Default Network ACL"
+  type        = string
+  default     = null
+}
+
+variable "default_network_acl_ingress" {
+  description = "List of maps of ingress rules to set on the Default Network ACL"
+  type        = list(map(string))
+  default = [
+    {
+      rule_no    = 100
+      action     = "allow"
+      from_port  = 0
+      to_port    = 0
+      protocol   = "-1"
+      cidr_block = "0.0.0.0/0"
+    },
+    {
+      rule_no         = 101
+      action          = "allow"
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      ipv6_cidr_block = "::/0"
+    },
+  ]
+}
+
+variable "default_network_acl_egress" {
+  description = "List of maps of egress rules to set on the Default Network ACL"
+  type        = list(map(string))
+  default = [
+    {
+      rule_no    = 100
+      action     = "allow"
+      from_port  = 0
+      to_port    = 0
+      protocol   = "-1"
+      cidr_block = "0.0.0.0/0"
+    },
+    {
+      rule_no         = 101
+      action          = "allow"
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      ipv6_cidr_block = "::/0"
+    },
+  ]
+}
+
+variable "default_network_acl_tags" {
+  description = "Additional tags for the Default Network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+######################################
+# Default Route
+######################################
+
+variable "manage_default_route_table" {
+  description = "Should be true to manage default route table"
+  type        = bool
+  default     = true
+}
+
+variable "default_route_table_name" {
+  description = "Name to be used on the default route table"
+  type        = string
+  default     = null
+}
+
+variable "default_route_table_propagating_vgws" {
+  description = "List of virtual gateways for propagation"
+  type        = list(string)
+  default     = []
+}
+
+variable "default_route_table_routes" {
+  description = "Configuration block of routes. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table#route"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "default_route_table_tags" {
+  description = "Additional tags for the default route table"
+  type        = map(string)
+  default     = {}
+}

--- a/templates/terraform/aws/vpc/versions.tf
+++ b/templates/terraform/aws/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.20"
+    }
+  }
+}


### PR DESCRIPTION
This is part 1 of refactoring the terraform modules to be more composable. The PR adds a common templates directory and AWS modules.

- adds the reusable aws modules for (VPC and EC2) resources

closes #142 