### PR TITLE
add cloudflare module for DNS records of resources

### DIFF
--- a/templates/terraform/cloudflare-records/main.tf
+++ b/templates/terraform/cloudflare-records/main.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_record" "main" {
+  for_each = { for cf in var.cloudflare_records : cf.name => cf }
+  zone_id  = each.value.zone_id
+  type     = each.value.type
+  ttl      = each.value.ttl
+  name     = each.value.name
+  proxied  = each.value.proxied
+  value    = each.value.value
+  tags     = each.value.tags
+}

--- a/templates/terraform/cloudflare-records/outputs.tf
+++ b/templates/terraform/cloudflare-records/outputs.tf
@@ -1,0 +1,14 @@
+output "cloudflare_dns_record_details" {
+    value = { for k, record in cloudflare_record.main : record.name => {
+        id      = record.id
+        zone_id = record.zone_id
+        type    = record.type
+        ttl     = record.ttl
+        name    = record.name
+        proxied = record.proxied
+        value   = record.value
+        tags    = record.tags
+        comment = record.comment
+      }
+    }
+  }

--- a/templates/terraform/cloudflare-records/variables.tf
+++ b/templates/terraform/cloudflare-records/variables.tf
@@ -1,0 +1,24 @@
+variable "cloudflare_secrets" {
+  description = "Cloudflare secrets"
+  type = object({
+    api_token  = string
+    account_id = string
+  })
+  sensitive = true
+}
+
+variable "cloudflare_records" {
+  description = "Cloudflare Records struct"
+  type = list(object({
+    zone_id = optional(string, "")
+    name    = optional(string, "")
+    value   = optional(string, "")
+    ttl     = optional(number, 1)
+    type    = optional(string, "A")
+    proxied = optional(bool, true)
+    comment = optional(string, "")
+    tags    = optional(set(string), [])
+  }))
+
+  default = []
+}

--- a/templates/terraform/cloudflare-records/versions.tf
+++ b/templates/terraform/cloudflare-records/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "4.7.1"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_secrets.api_token
+}


### PR DESCRIPTION
This is part 4 of refactoring the terraform modules to be more composable.

- add module for cloudflare records for resources to re-use.

closes #142 