### PR TITLE
create rewards squid terraform declaration

### DIFF
--- a/explorer/terraform/aws/ec2/gemini-3h/base/bootstrap_reward_squid_provisioner.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/base/bootstrap_reward_squid_provisioner.tf
@@ -1,0 +1,388 @@
+locals {
+  blue_reward_squid_node_ip_v4 = flatten([
+    [aws_instance.reward_squid_blue_node.*.public_ip],
+    ]
+  )
+
+  green_reward_squid_node_ip_v4 = flatten([
+    [aws_instance.reward_squid_green_node.*.public_ip],
+    ]
+  )
+}
+
+resource "null_resource" "setup-blue-reward-squrd-nodes" {
+  count = length(local.blue_reward_squid_node_ip_v4)
+
+  depends_on = [aws_instance.reward_squid_blue_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.blue_reward_squid_node_ip_v4)
+  }
+
+  lifecycle {
+    ignore_changes = [triggers]
+  }
+  connection {
+    host           = local.blue_reward_squid_node_ip_v4[count.index]
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = var.aws_key_name
+    private_key    = file("${var.private_key_path}")
+    timeout        = "300s"
+  }
+
+  # create squid dir
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /home/${var.ssh_user}/squid",
+      "sudo mkdir -p /home/${var.ssh_user}/squid/postgresql",
+      "sudo mkdir -p /home/${var.ssh_user}/squid/postgresql/conf",
+      "sudo mkdir -p /home/${var.ssh_user}/squid/postgresql/data",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/squid/ && sudo chmod -R 750 /home/${var.ssh_user}/squid/"
+    ]
+  }
+
+  # copy postgres config file
+  provisioner "file" {
+    source      = "${var.path_to_configs}/postgresql.conf"
+    destination = "/home/${var.ssh_user}/squid/postgresql/conf/postgresql.conf"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_squid_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/squid/create_compose_file.sh"
+  }
+
+  # copy docker install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/install_docker.sh"
+    destination = "/home/${var.ssh_user}/squid/install_docker.sh"
+  }
+
+  # copy nginx config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/nginx-squid.conf"
+    destination = "/home/${var.ssh_user}/squid/backend.conf"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_configs}/cors-settings.conf"
+    destination = "/home/${var.ssh_user}/squid/cors-settings.conf"
+  }
+  # copy nginx install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/install_nginx.sh"
+    destination = "/home/${var.ssh_user}/squid/install_nginx.sh"
+  }
+
+}
+
+resource "null_resource" "setup-green-reward-squid-nodes" {
+  count = length(local.green_reward_squid_node_ip_v4)
+
+  depends_on = [aws_instance.reward_squid_green_node]
+
+  # trigger on node ip changes
+  triggers = {
+    cluster_instance_ipv4s = join(",", local.green_reward_squid_node_ip_v4)
+  }
+
+  lifecycle {
+    ignore_changes = [triggers]
+  }
+
+  connection {
+    host           = local.green_reward_squid_node_ip_v4[count.index]
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = var.aws_key_name
+    private_key    = file("${var.private_key_path}")
+    timeout        = "300s"
+  }
+
+  # create squid dir
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /home/${var.ssh_user}/squid",
+      "mkdir -p /home/${var.ssh_user}/squid/postgresql",
+      "mkdir -p /home/${var.ssh_user}/squid/postgresql/{conf,data}",
+      "sudo chown -R ${var.ssh_user}:${var.ssh_user} /home/${var.ssh_user}/squid/ && sudo chmod -R 750 /home/${var.ssh_user}/squid/"
+    ]
+  }
+
+  # copy postgres config file
+  provisioner "file" {
+    source      = "${var.path_to_configs}/postgresql.conf"
+    destination = "/home/${var.ssh_user}/squid/postgresql/conf/postgresql.conf"
+  }
+
+  # copy compose file creation script
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/create_squid_node_compose_file.sh"
+    destination = "/home/${var.ssh_user}/squid/create_compose_file.sh"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/set_env_vars.sh"
+    destination = "/home/${var.ssh_user}/squid/set_env_vars.sh"
+  }
+
+  # copy docker install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/install_docker.sh"
+    destination = "/home/${var.ssh_user}/squid/install_docker.sh"
+  }
+
+  # copy nginx config files
+  provisioner "file" {
+    source      = "${var.path_to_configs}/nginx-squid.conf"
+    destination = "/home/${var.ssh_user}/squid/backend.conf"
+  }
+
+  provisioner "file" {
+    source      = "${var.path_to_configs}/cors-settings.conf"
+    destination = "/home/${var.ssh_user}/squid/cors-settings.conf"
+  }
+  # copy nginx install file
+  provisioner "file" {
+    source      = "${var.path_to_scripts}/install_nginx.sh"
+    destination = "/home/${var.ssh_user}/squid/install_nginx.sh"
+  }
+
+}
+
+
+resource "null_resource" "prune-blue-reward-squrd-nodes" {
+  count      = var.blue-squid-node-config.prune ? length(local.blue_reward_squid_node_ip_v4) : 0
+  depends_on = [null_resource.setup-blue-reward-squrd-nodes]
+
+  triggers = {
+    prune = var.blue-squid-node-config.prune
+  }
+
+  connection {
+    host           = local.blue_reward_squid_node_ip_v4[count.index]
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = var.aws_key_name
+    private_key    = file("${var.private_key_path}")
+    timeout        = "300s"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo docker ps -aq | xargs docker stop",
+      "sudo docker system prune -a -f && docker volume ls -q | xargs docker volume rm -f",
+      "cat /dev/null > $HOME/.bash_profile"
+    ]
+  }
+}
+
+resource "null_resource" "prune-green-reward-squid-nodes" {
+  count      = var.green-reward-squid-node-config.prune ? length(local.green_reward_squid_node_ip_v4) : 0
+  depends_on = [null_resource.setup-green-reward-squid-nodes]
+
+  triggers = {
+    prune = var.green-reward-squid-node-config.prune
+  }
+
+  connection {
+    host           = local.green_reward_squid_node_ip_v4[count.index]
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = var.aws_key_name
+    private_key    = file("${var.private_key_path}")
+    timeout        = "300s"
+  }
+
+  # prune network
+  provisioner "remote-exec" {
+    inline = [
+      "sudo docker ps -aq | xargs sudo docker stop",
+      "sudo docker system prune -a -f && sudo docker volume ls -q | xargs sudo docker volume rm -f",
+      "cat /dev/null > $HOME/.bash_profile",
+    ]
+  }
+}
+
+resource "null_resource" "start-blue-reward-squrd-nodes" {
+  count = length(local.blue_reward_squid_node_ip_v4)
+
+  depends_on = [null_resource.setup-blue-reward-squrd-nodes]
+
+  # trigger on node deployment environment change
+  triggers = {
+    deployment_color = var.blue-squid-node-config.deployment-color
+  }
+
+  connection {
+    host           = local.blue_reward_squid_node_ip_v4[count.index]
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = var.aws_key_name
+    private_key    = file("${var.private_key_path}")
+    timeout        = "300s"
+
+  }
+
+  # install deployments
+  provisioner "remote-exec" {
+    inline = [
+      # install nginx, certbot, docker and docker compose
+      "chmod +x /home/${var.ssh_user}/squid/install_docker.sh",
+      "sudo bash /home/${var.ssh_user}/squid/install_docker.sh",
+      # copy files
+      "sudo cp -f /home/${var.ssh_user}/squid/cors-settings.conf /etc/nginx/cors-settings.conf",
+      "sudo cp -f /home/${var.ssh_user}/squid/backend.conf /etc/nginx/backend.conf",
+      "chmod +x /home/${var.ssh_user}/squid/install_nginx.sh",
+      "sudo bash /home/${var.ssh_user}/squid/install_nginx.sh",
+      # start systemd services
+      "sudo systemctl daemon-reload",
+      # start nginx
+      "sudo systemctl enable nginx",
+      "sudo systemctl start nginx",
+      # install certbot & generate domain
+      "sudo certbot --nginx --non-interactive -v --agree-tos -m alerts@subspace.network -d squid.${var.network_name}.subspace.network -d ${var.blue-squid-node-config.domain-prefix}.squid.${var.network_name}.subspace.network",
+      "sudo systemctl restart nginx",
+      # install netdata
+      "sudo sh -c \"curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --non-interactive --nightly-channel --claim-token ${var.netdata_token} --claim-url https://app.netdata.cloud\"",
+      # set hostname
+      "sudo hostnamectl set-hostname squid-${var.blue-squid-node-config.network-name}",
+
+      # create .env file
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/squid/.env",
+      "echo DOMAIN_PREFIX=${var.blue-squid-node-config.domain-prefix} >> /home/${var.ssh_user}/squid/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/squid/.env",
+      "echo DOCKER_TAG=${var.blue-squid-node-config.docker-tag} >> /home/${var.ssh_user}/squid/.env",
+      "echo NODE_NAME=SUBSQUID_GEMINI_3h >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_HOST=db >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_PORT=5432 >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_USER=postgres >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_DB=squid-archive >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_PASSWORD=${var.postgres_password} >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_TYPE=postgres >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_HOST=db >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_PORT=5432 >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_USER=postgres >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_NAME=squid-archive >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_PASS=${var.postgres_password} >> /home/${var.ssh_user}/squid/.env",
+      "echo ARCHIVE_ENDPOINT=https://archive.gemini-3h.subspace.network/api >> /home/${var.ssh_user}/squid/.env",
+      "echo CHAIN_RPC_ENDPOINT=wss://rpc-0.gemini-3h.subspace.network/ws >> /home/${var.ssh_user}/squid/.env",
+      "echo PROCESSOR_HEALTH_HOST=http://processor:3000 >> /home/${var.ssh_user}/squid/.env",
+      "echo PROCESSOR_HEALTH_PORT=7070 >> /home/${var.ssh_user}/squid/.env",
+      "echo HEALTH_CHECK_PORT=8080 >> /home/${var.ssh_user}/squid/.env",
+      "echo INGEST_HEALTH_HOST=http://ingest:9090 >> /home/${var.ssh_user}/squid/.env",
+      "echo INGEST_HEALTH_PORT=7070 >> /home/${var.ssh_user}/squid/.env",
+      "echo MY_SECRET=${var.prometheus_secret} >> /home/${var.ssh_user}/squid/.env",
+
+      # create docker compose file
+      "chmod +x /home/${var.ssh_user}/squid/create_compose_file.sh",
+      "bash /home/${var.ssh_user}/squid/create_compose_file.sh",
+      # start docker daemon
+      "sudo systemctl enable --now docker.service",
+      "sudo systemctl restart docker.service",
+      "sudo docker compose -f ./squid/docker-compose.yml up -d",
+      "echo 'Installation Complete'",
+    ]
+  }
+
+}
+
+
+resource "null_resource" "start-green-reward-squid-nodes" {
+  count = length(local.green_reward_squid_node_ip_v4)
+
+  depends_on = [null_resource.setup-green-reward-squid-nodes]
+
+  # trigger on node deployment environment change
+  triggers = {
+    deployment_color = var.green-reward-squid-node-config.deployment-color
+  }
+
+  connection {
+    host           = local.green_reward_squid_node_ip_v4[count.index]
+    user           = var.ssh_user
+    type           = "ssh"
+    agent          = true
+    agent_identity = var.aws_key_name
+    private_key    = file("${var.private_key_path}")
+    timeout        = "300s"
+
+  }
+
+  # install nginx, certbot, docker and docker compose
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/squid/install_docker.sh",
+      "sudo bash /home/${var.ssh_user}/squid/install_docker.sh",
+      # install nginx
+      "chmod +x /home/${var.ssh_user}/squid/install_nginx.sh",
+      "sudo bash /home/${var.ssh_user}/squid/install_nginx.sh",
+    ]
+  }
+
+  # install deployments
+  provisioner "remote-exec" {
+    inline = [
+      # copy files
+      "sudo cp -f /home/${var.ssh_user}/squid/cors-settings.conf /etc/nginx/cors-settings.conf",
+      "sudo cp -f /home/${var.ssh_user}/squid/backend.conf /etc/nginx/backend.conf",
+      "chmod +x /home/${var.ssh_user}/squid/install_nginx.sh",
+      "sudo bash /home/${var.ssh_user}/squid/install_nginx.sh",
+      # start systemd services
+      "sudo systemctl daemon-reload",
+      # start nginx
+      "sudo systemctl enable nginx",
+      "sudo systemctl start nginx",
+      # install certbot & generate domain
+      "sudo certbot --nginx --non-interactive -v --agree-tos -m alerts@subspace.network -d squid.${var.network_name}.subspace.network -d ${var.green-reward-squid-node-config.domain-prefix}.${var.network_name}.subspace.network",
+      "sudo systemctl restart nginx",
+      # set hostname
+      "sudo hostnamectl set-hostname squid-${var.green-reward-squid-node-config.network-name}",
+      # create .env file
+      "echo NETWORK_NAME=${var.network_name} >> /home/${var.ssh_user}/squid/.env",
+      "echo DOMAIN_PREFIX=${var.green-reward-squid-node-config.domain-prefix} >> /home/${var.ssh_user}/squid/.env",
+      "echo NR_API_KEY=${var.nr_api_key} >> /home/${var.ssh_user}/squid/.env",
+      "echo DOCKER_TAG=${var.green-reward-squid-node-config.docker-tag} >> /home/${var.ssh_user}/squid/.env",
+      "echo NODE_NAME=SUBSQUID_GEMINI_3h >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_HOST=db >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_PORT=5432 >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_USER=postgres >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_DB=squid-archive >> /home/${var.ssh_user}/squid/.env",
+      "echo POSTGRES_PASSWORD=${var.postgres_password} >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_TYPE=postgres >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_HOST=db >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_PORT=5432 >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_USER=postgres >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_NAME=squid-archive >> /home/${var.ssh_user}/squid/.env",
+      "echo DB_PASS=${var.postgres_password} >> /home/${var.ssh_user}/squid/.env",
+      "echo ARCHIVE_ENDPOINT=https://archive.gemini-3h.subspace.network/api >> /home/${var.ssh_user}/squid/.env",
+      "echo CHAIN_RPC_ENDPOINT=wss://rpc-0.gemini-3h.subspace.network/ws >> /home/${var.ssh_user}/squid/.env",
+      "echo PROCESSOR_HEALTH_HOST=http://processor:3000 >> /home/${var.ssh_user}/squid/.env",
+      "echo PROCESSOR_HEALTH_PORT=7070 >> /home/${var.ssh_user}/squid/.env",
+      "echo HEALTH_CHECK_PORT=8080 >> /home/${var.ssh_user}/squid/.env",
+      "echo INGEST_HEALTH_HOST=http://ingest:9090 >> /home/${var.ssh_user}/squid/.env",
+      "echo INGEST_HEALTH_PORT=7070 >> /home/${var.ssh_user}/squid/.env",
+      "echo MY_SECRET=${var.prometheus_secret} >> /home/${var.ssh_user}/squid/.env",
+
+      # create docker compose file
+      "chmod +x /home/${var.ssh_user}/squid/create_compose_file.sh",
+      "bash /home/${var.ssh_user}/squid/create_compose_file.sh",
+
+      # start docker daemon
+      "sudo systemctl enable --now docker.service",
+      "sudo systemctl restart docker.service",
+      "sudo docker compose -f ./squid/docker-compose.yml up -d",
+      "echo 'Installation Complete'",
+    ]
+  }
+
+}

--- a/explorer/terraform/aws/ec2/gemini-3h/base/dns.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/base/dns.tf
@@ -20,6 +20,33 @@ resource "cloudflare_record" "squid-green" {
   ttl     = "3600"
 }
 
+resource "cloudflare_record" "reward-squid-blue" {
+  count   = var.blue-reward-squid-node-config.instance-count-blue > 0 ? var.blue-reward-squid-node-config.instance-count-blue : 0
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "${var.blue-reward-squid-node-config.domain-prefix}.${var.blue-reward-squid-node-config.network-name}"
+  value   = local.blue_reward_squid_node_ip_v4[count.index]
+  type    = "A"
+  ttl     = "3600"
+}
+
+resource "cloudflare_record" "reward-squid-green" {
+  count   = var.green-reward-squid-node-config.instance-count-green > 0 ? var.green-reward-squid-node-config.instance-count-green : 0
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "${var.green-reward-squid-node-config.domain-prefix}.${var.green-reward-squid-node-config.network-name}"
+  value   = local.green_reward_squid_node_ip_v4[count.index]
+  type    = "A"
+  ttl     = "3600"
+}
+
+resource "cloudflare_record" "reward-squid-live" {
+  count   = var.blue-reward-squid-node-config.instance-count-blue > 0 ? var.blue-reward-squid-node-config.instance-count-blue : 0
+  zone_id = data.cloudflare_zone.cloudflare_zone.id
+  name    = "squid.${var.network_name}"
+  value   = local.blue_squid_node_ip_v4[count.index]
+  type    = "A"
+  ttl     = "3600"
+}
+
 resource "cloudflare_record" "squid-live" {
   count   = var.blue-squid-node-config.instance-count-blue > 0 ? var.blue-squid-node-config.instance-count-blue : 0
   zone_id = data.cloudflare_zone.cloudflare_zone.id

--- a/explorer/terraform/aws/ec2/gemini-3h/base/outputs.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/base/outputs.tf
@@ -20,6 +20,38 @@ output "squid_blue_node_ami" {
   value = aws_instance.squid_blue_node.*.ami
 }
 
+output "reward_squid_blue_node_server_id" {
+  value = aws_instance.reward_squid_blue_node.*.id
+}
+
+output "reward_squid_blue_node_public_ip" {
+  value = aws_instance.reward_squid_blue_node.*.public_ip
+}
+
+output "reward_squid_blue_node_private_ip" {
+  value = aws_instance.reward_squid_blue_node.*.private_ip
+}
+
+output "reward_squid_blue_node_ami" {
+  value = aws_instance.reward_squid_blue_node.*.ami
+}
+
+output "reward_squid_green_node_server_id" {
+  value = aws_instance.reward_squid_green_node.*.id
+}
+
+output "reward_squid_green_node_public_ip" {
+  value = aws_instance.reward_squid_green_node.*.public_ip
+}
+
+output "reward_squid_green_node_private_ip" {
+  value = aws_instance.reward_squid_green_node.*.private_ip
+}
+
+output "reward_squid_green_node_ami" {
+  value = aws_instance.reward_squid_green_node.*.ami
+}
+
 output "nova_squid_blue_node_server_id" {
   value = aws_instance.nova_squid_blue_node.*.id
 }
@@ -110,6 +142,9 @@ output "dns-records" {
     cloudflare_record.squid-blue[*].hostname,
     cloudflare_record.squid-green[*].hostname,
     cloudflare_record.squid-live[*].hostname,
+    cloudflare_record.reward-squid-blue[*].hostname,
+    cloudflare_record.reward-squid-green[*].hostname,
+    cloudflare_record.reward-squid-live[*].hostname,
     cloudflare_record.archive[*].hostname,
     cloudflare_record.nova-squid-blue[*].hostname,
     cloudflare_record.nova-squid-green[*].hostname,

--- a/explorer/terraform/aws/ec2/gemini-3h/base/scripts/create_reward_squid_node_compose_file.sh
+++ b/explorer/terraform/aws/ec2/gemini-3h/base/scripts/create_reward_squid_node_compose_file.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+source $HOME/.bash_profile
+cat > $HOME/squid/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  db_data: {}
+
+services:
+  db:
+    image: postgres:16
+    shm_size: 1gb
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - type: bind
+        source: $HOME/squid/postgresql/conf/postgresql.conf
+        target: /etc/postgresql/postgresql.conf
+        read_only: true
+    environment:
+      POSTGRES_DB: squid-archive
+      POSTGRES_USER: \${POSTGRES_USER}
+      POSTGRES_PASSWORD: \${POSTGRES_PASSWORD}
+    expose:
+      - "5432"
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+
+  run-migrations:
+    image: ghcr.io/subspace/blockexplorer-rewards:\${DOCKER_TAG}
+    restart: on-failure:5
+    environment:
+      DB_HOST: \${DB_HOST}
+      # provide DB name
+      DB_NAME: \${DB_NAME}
+      # provide DB password
+      DB_PASS: \${DB_PASS}
+    depends_on:
+      - db
+    command: "npm run db:migrate"
+
+  rewards-processor:
+    image: ghcr.io/subspace/blockexplorer-rewards:\${DOCKER_TAG}
+    restart: on-failure
+    environment:
+      # provide archive endpoint
+      ARCHIVE_ENDPOINT: \${ARCHIVE_ENDPOINT}
+      # provide chain RPC endpoint
+      CHAIN_RPC_ENDPOINT: \${CHAIN_RPC_ENDPOINT}
+      DB_HOST: \${DB_HOST}
+      # provide DB name
+      DB_NAME: \${DB_NAME}
+      # provide DB password
+      DB_PASS: \${DB_PASS}
+    depends_on:
+      - db
+      - run-migrations
+    ports:
+      - "3000:3000"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+
+  graphql:
+    image: ghcr.io/subspace/blockexplorer-api-server:\${DOCKER_TAG}
+    depends_on:
+      - db
+      - run-migrations
+      - processor
+    environment:
+      DB_HOST: \${DB_HOST}
+      # provide DB name
+      DB_NAME: \${DB_NAME}
+      # provide DB password
+      DB_PASS: \${DB_PASS}
+    ports:
+      - "4350:4000"
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+
+  agent:
+    container_name: newrelic-infra
+    image: newrelic/infrastructure:latest
+    cap_add:
+      - SYS_PTRACE
+    network_mode: bridge
+    pid: host
+    privileged: true
+    volumes:
+      - "/:/host:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      NRIA_LICENSE_KEY: "\${NR_API_KEY}"
+      NRIA_DISPLAY_NAME: "squid-\${NETWORK_NAME}"
+    restart: unless-stopped
+
+  pg-health-check:
+    image: ghcr.io/subspace/health-check:latest
+    environment:
+      POSTGRES_HOST: \${POSTGRES_HOST}
+      POSTGRES_PORT: \${POSTGRES_PORT}
+      PORT: \${HEALTH_CHECK_PORT}
+      SECRET: \${MY_SECRET}
+    command: "postgres"
+    ports:
+      - 8080:8080
+
+  prom-health-check:
+    image: ghcr.io/subspace/health-check:latest
+    environment:
+      PROMETHEUS_HOST: \${PROCESSOR_HEALTH_HOST}
+      PORT: \${PROCESSOR_HEALTH_PORT}
+      SECRET: \${MY_SECRET}
+    command: "prometheus"
+    ports:
+      - 7070:7070
+EOF

--- a/explorer/terraform/aws/ec2/gemini-3h/base/squids.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/base/squids.tf
@@ -139,6 +139,147 @@ resource "aws_instance" "squid_green_node" {
 
 }
 
+resource "aws_instance" "reward_squid_blue_node" {
+  count             = length(var.aws_region) * var.blue-reward-squid-node-config.instance-count-blue > 0 ? var.blue-reward-squid-node-config.instance-count-blue : 0
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.blue-reward-squid-node-config.instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, 0)
+  availability_zone = element(var.azs, 0)
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.gemini-squid-sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+
+  ebs_optimized = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.blue-reward-squid-node-config.disk-volume-size
+    volume_type = var.blue-reward-squid-node-config.disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+  tags = {
+    name       = "squid-${var.blue-reward-squid-node-config.network-name}"
+    Name       = "${var.blue-reward-squid-node-config.domain-prefix}-${var.blue-squid-node-config.network-name}"
+    role       = "block explorer"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    aws_internet_gateway.squid-gw,
+    aws_instance.archive_node,
+
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ ami, instance_type]
+
+  }
+
+  # # base installation
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "export DEBIAN_FRONTEND=noninteractive",
+      "sudo apt update -y",
+      "sudo DEBIAN_FRONTEND=noninteractive apt install wget gnupg openssl net-tools git -y",
+      # install monitoring
+      "sudo wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh --non-interactive --nightly-channel --claim-token ${var.netdata_token} --claim-url https://app.netdata.cloud",
+
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "180s"
+  }
+
+}
+
+
+resource "aws_instance" "reward_squid_green_node" {
+  count             = length(var.aws_region) * var.green-reward-squid-node-config .instance-count-green > 0 ? var.green-reward-squid-node-config .instance-count-green : 0
+  ami               = data.aws_ami.ubuntu_amd64.image_id
+  instance_type     = var.green-reward-squid-node-config .instance-type
+  subnet_id         = element(aws_subnet.public_subnets.*.id, count.index)
+  availability_zone = element(var.azs, count.index)
+  # Security Group
+  vpc_security_group_ids = ["${aws_security_group.gemini-squid-sg.id}"]
+  # the Public SSH key
+  key_name                    = var.aws_key_name
+  associate_public_ip_address = true
+
+  ebs_optimized = true
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.green-reward-squid-node-config .disk-volume-size
+    volume_type = var.green-reward-squid-node-config .disk-volume-type
+    iops        = 3000
+    throughput  = 250
+  }
+
+  tags = {
+    name       = "squid-${var.green-reward-squid-node-config .network-name}"
+    Name       = "${var.green-reward-squid-node-config .domain-prefix}-${var.green-reward-squid-node-config .network-name}"
+    role       = "block explorer"
+    os_name    = "ubuntu"
+    os_version = "22.04"
+    arch       = "x86_64"
+  }
+
+  depends_on = [
+    aws_subnet.public_subnets,
+    aws_internet_gateway.squid-gw,
+    aws_instance.archive_node,
+  ]
+
+  lifecycle {
+
+    ignore_changes = [ ami, instance_type]
+
+  }
+
+  # # base installation
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "export DEBIAN_FRONTEND=noninteractive",
+      "sudo apt update -y",
+      "sudo apt upgrade -y",
+      "sudo apt install git curl wget gnupg openssl net-tools git -y",
+      # install monitoring
+      "sudo wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh --non-interactive --nightly-channel --claim-token ${var.netdata_token} --claim-url https://app.netdata.cloud",
+
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "180s"
+  }
+
+}
+
 resource "aws_instance" "nova_squid_blue_node" {
   count             = length(var.aws_region) * var.nova-blue-squid-node-config.instance-count-blue > 0 ? var.nova-blue-squid-node-config.instance-count-blue : 0
   ami               = data.aws_ami.ubuntu_amd64.image_id

--- a/explorer/terraform/aws/ec2/gemini-3h/base/variables.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/base/variables.tf
@@ -131,6 +131,42 @@ variable "green-squid-node-config" {
   })
 }
 
+variable "blue-reward-squid-node-config" {
+  description = "squid blue configuration"
+  type = object({
+    deployment-color    = string
+    network-name        = string
+    domain-prefix       = string
+    docker-tag          = string
+    instance-type       = string
+    deployment-version  = number
+    regions             = list(string)
+    instance-count-blue = number
+    prune               = bool
+    disk-volume-size    = number
+    disk-volume-type    = string
+    environment         = string
+  })
+}
+
+variable "green-reward-squid-node-config" {
+  description = "squid blue configuration"
+  type = object({
+    deployment-color     = string
+    network-name         = string
+    domain-prefix        = string
+    docker-tag           = string
+    instance-type        = string
+    deployment-version   = number
+    regions              = list(string)
+    instance-count-green = number
+    prune                = bool
+    disk-volume-size     = number
+    disk-volume-type     = string
+    environment          = string
+  })
+}
+
 variable "nova-blue-squid-node-config" {
   description = "squid blue configuration"
   type = object({

--- a/explorer/terraform/aws/ec2/gemini-3h/modules/squids/main.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/modules/squids/main.tf
@@ -34,6 +34,36 @@ module "squids" {
     environment          = "staging"
   }
 
+
+  blue-reward-squid-node-config = {
+    deployment-color    = "blue"
+    network-name        = "${var.network_name}"
+    domain-prefix       = "rewards.blue"
+    docker-tag          = "latest"
+    instance-type       = var.instance_type
+    deployment-version  = 0
+    regions             = var.aws_region
+    instance-count-blue = var.instance_count_blue
+    disk-volume-size    = var.disk_volume_size
+    disk-volume-type    = var.disk_volume_type
+    prune               = false
+    environment         = "production"
+  }
+
+  green-reward-squid-node-config = {
+    deployment-color     = "green"
+    network-name         = "${var.network_name}"
+    domain-prefix        = "rewards.green"
+    docker-tag           = "latest"
+    instance-type        = var.instance_type
+    deployment-version   = 0
+    regions              = var.aws_region
+    instance-count-green = 0# var.instance_count_green
+    disk-volume-size     = var.disk_volume_size
+    disk-volume-type     = var.disk_volume_type
+    prune                = false
+    environment          = "staging"
+  }
   nova-blue-squid-node-config = {
     deployment-color    = "blue"
     network-name        = "${var.network_name}"

--- a/explorer/terraform/aws/ec2/gemini-3h/modules/squids/outputs.tf
+++ b/explorer/terraform/aws/ec2/gemini-3h/modules/squids/outputs.tf
@@ -8,6 +8,16 @@ output "squid-node-green-ipv4-addresses" {
   description = "Squid green node IPv4 Addresses"
 }
 
+output "reward-squid-node-blue-ipv4-addresses" {
+  value       = module.squids.reward_squid_blue_node_public_ip
+  description = "Reward squid blue node IPv4 Addresses"
+}
+
+output "reward-squid-node-green-ipv4-addresses" {
+  value       = module.squids.reward_squid_green_node_public_ip
+  description = "Reward squid green node IPv4 Addresses"
+}
+
 output "nova-squid-node-blue-ipv4-addresses" {
   value       = module.squids.nova_squid_blue_node_public_ip
   description = "Nova Squid blue node IPv4 Addresses"


### PR DESCRIPTION
The PR adds another squid type `rewards squid` to the explorer terraform declarations. This squid is used to process rewards separately and decouple the processing from the main squid to improve on indexing performance. The PR adds a blue/green environment for this squid.