### PR TITLE
Fixes network primitives

### DIFF
--- a/templates/scripts/create_bootstrap_node_compose_file.sh
+++ b/templates/scripts/create_bootstrap_node_compose_file.sh
@@ -154,7 +154,7 @@ cat >> ~/subspace/docker-compose.yml << EOF
 EOF
 
 for (( i = 0; i < node_count; i++ )); do
-  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR_TCP=//p" ~/subspace/node_keys.txt)
   echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
   echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
 done

--- a/templates/scripts/create_domain_node_compose_file.sh
+++ b/templates/scripts/create_domain_node_compose_file.sh
@@ -77,6 +77,7 @@ services:
     image: ghcr.io/\${NODE_ORG}/node:\${NODE_TAG}
     volumes:
       - archival_node_data:/var/subspace:rw
+      - ./keystore:/var/subspace/keystore:ro
     restart: unless-stopped
     ports:
       - "30333:30333/tcp"


### PR DESCRIPTION
The PR mounts the keystore directory as a read-only volume and changes the bootstrap node to use the TCP multi-address based on parsing from respective key file.