### PR TITLE
Remove null resource to inject keystore

### DIFF
--- a/templates/terraform/network-primitives/domain_node_provisioner.tf
+++ b/templates/terraform/network-primitives/domain_node_provisioner.tf
@@ -191,22 +191,3 @@ resource "null_resource" "start-domain-nodes" {
     ]
   }
 }
-
-resource "null_resource" "inject-domain-keystore" {
-  # for now we have one executor running. Should change here when multiple executors are expected.
-  count      = length(local.domain_nodes_ip_v4) > 0 ? 1 : 0
-  depends_on = [null_resource.start-domain-nodes]
-  # trigger on node deployment version change
-  triggers = {
-    deployment_version = var.domain-node-config.deployment-version
-  }
-
-  connection {
-    host        = local.domain_node_ip_v4[0]
-    user        = var.ssh_user
-    type        = "ssh"
-    agent       = true
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-}

--- a/templates/terraform/network-primitives/rpc_node_provisioner.tf
+++ b/templates/terraform/network-primitives/rpc_node_provisioner.tf
@@ -178,22 +178,3 @@ resource "null_resource" "start-rpc-nodes" {
     ]
   }
 }
-
-resource "null_resource" "inject-keystore" {
-  # for now we have one executor running. Should change here when multiple executors are expected.
-  count      = length(local.rpc_nodes_ip_v4) > 0 ? 1 : 0
-  depends_on = [null_resource.start-rpc-nodes]
-  # trigger on node deployment version change
-  triggers = {
-    deployment_version = var.rpc-node-config.deployment-version
-  }
-
-  connection {
-    host        = local.rpc_node_ip_v4[0]
-    user        = var.ssh_user
-    type        = "ssh"
-    agent       = true
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-}


### PR DESCRIPTION
The null resource to inject keystore files is obsolete and can be removed since we directly mount it now #273 as a volume in docker compose manifest.