### PR TITLE
extend AWS module and refactor network primitives to modules

### DIFF
--- a/templates/terraform/aws/ec2/main.tf
+++ b/templates/terraform/aws/ec2/main.tf
@@ -193,6 +193,26 @@ resource "aws_instance" "this" {
     ignore_changes = [ami, ipv6_address_count]
 
   }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
+
 }
 
 
@@ -359,6 +379,31 @@ resource "aws_spot_instance_request" "this" {
 
   tags        = merge({ "Name" = var.name }, var.instance_tags, var.tags)
   volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
+
+  lifecycle {
+
+    ignore_changes = [ami, ipv6_address_count]
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait",
+      "sudo apt update -y",
+    ]
+
+    on_failure = continue
+
+  }
+
+  # Setting up the ssh connection
+  connection {
+    type        = "ssh"
+    host        = element(self.*.public_ip, count.index)
+    user        = var.ssh_user
+    private_key = file("${var.private_key_path}")
+    timeout     = "300s"
+  }
 }
 
 ######################################

--- a/templates/terraform/aws/ec2/variables.tf
+++ b/templates/terraform/aws/ec2/variables.tf
@@ -10,6 +10,24 @@ variable "create" {
     default     = ""
   }
 
+  variable ssh_key_name {
+    description = "The name of the SSH key pair to use"
+    type        = string
+    default     = null
+  }
+
+  variable private_key_path {
+    description = "The path to the SSH public key to use"
+    type        = string
+    default     = null
+  }
+
+  variable ssh_user {
+    description = "The SSH user to use"
+    type        = string
+    default     = "ec2-user"
+  }
+
   variable "ami_ssm_parameter" {
     description = "SSM parameter name for the AMI ID. For Amazon Linux AMI SSM parameters see [reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html)"
     type        = string

--- a/templates/terraform/network-primitives/instances.tf
+++ b/templates/terraform/network-primitives/instances.tf
@@ -1,24 +1,30 @@
-resource "aws_instance" "bootstrap_node" {
+module "bootstrap_node" {
+  source = "../../terraform/aws/ec2"
+
   count              = length(var.aws_region) * var.bootstrap-node-config.instance-count
   ami                = data.aws_ami.ubuntu_amd64.image_id
   instance_type      = var.bootstrap-node-config.instance-type
   subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
   availability_zone  = var.azs
-  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
-  # Security Group
+  ipv6_address_count = 1
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
-  # the Public SSH key
   key_name                    = var.aws_key_name
   associate_public_ip_address = true
   ebs_optimized               = true
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_size = var.bootstrap-node-config.disk-volume-size
-    volume_type = var.bootstrap-node-config.disk-volume-type
-    iops        = 3000
-    throughput  = 250
-  }
 
+  root_block_device = [
+    {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      volume_size           = module.bootstrap-node-config.disk-volume-size
+      volume_type           = module.bootstrap-node-config.disk-volume-type
+      throughput            = 250
+      tags                  = {
+        Name = "bootstrap-[count.index]-${var.network_name}-root-volume"
+      }
+    }
+  ]
 
   tags = {
     Name       = "${var.network_name}-bootstrap-${count.index}"
@@ -31,58 +37,38 @@ resource "aws_instance" "bootstrap_node" {
 
   depends_on = [
     aws_subnet.public_subnets,
-    #aws_nat_gateway.nat_gateway,
     aws_internet_gateway.gw
   ]
-
-  lifecycle {
-
-    ignore_changes = [ami, ipv6_address_count]
-
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait",
-      "sudo apt update -y",
-    ]
-
-    on_failure = continue
-
-  }
-
-  # Setting up the ssh connection
-  connection {
-    type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
-    user        = var.ssh_user
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-
 }
 
-resource "aws_instance" "bootstrap_node_evm" {
-  count              = length(var.aws_region) * var.bootstrap-node-evm-config.instance-count
+module "bootstrap_node_evm" {
+  source = "../../terraform/aws/ec2"
+
+  count              = length(var.aws_region) * module.bootstrap-node-evm-config.instance-count
   ami                = data.aws_ami.ubuntu_amd64.image_id
-  instance_type      = var.bootstrap-node-evm-config.instance-type
+  instance_type      = module.bootstrap-node-evm-config.instance-type
   subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
   availability_zone  = var.azs
-  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ipv6_address_count = 1
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
   key_name                    = var.aws_key_name
   associate_public_ip_address = true
   ebs_optimized               = true
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_size = var.bootstrap-node-config.disk-volume-size
-    volume_type = var.bootstrap-node-config.disk-volume-type
-    iops        = 3000
-    throughput  = 250
-  }
-
+  root_block_device = [
+    {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      volume_size           = module.bootstrap-node-evm-config.disk-volume-size
+      volume_type           = module.bootstrap-node-evm-config.disk-volume-type
+      throughput            = 250
+      tags                  = {
+        Name = "bootstrap-evm-[count.index]-${var.network_name}-root-volume"
+      }
+    }
+  ]
 
   tags = {
     Name       = "${var.network_name}-bootstrap-evm-${count.index}"
@@ -98,54 +84,36 @@ resource "aws_instance" "bootstrap_node_evm" {
     #aws_nat_gateway.nat_gateway,
     aws_internet_gateway.gw
   ]
-
-  lifecycle {
-
-    ignore_changes = [ami, ipv6_address_count]
-
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait",
-      "sudo apt update -y",
-    ]
-
-    on_failure = continue
-
-  }
-
-  # Setting up the ssh connection
-  connection {
-    type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
-    user        = var.ssh_user
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-
 }
 
-resource "aws_instance" "full_node" {
-  count              = length(var.aws_region) * var.full-node-config.instance-count
+module "full_node" {
+  source = "../../terraform/aws/ec2"
+
+  count              = length(var.aws_region) * module.full-node-config.instance-count
   ami                = data.aws_ami.ubuntu_amd64.image_id
-  instance_type      = var.full-node-config.instance-type
+  instance_type      = module.full-node-config.instance-type
   subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
   availability_zone  = var.azs
-  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ipv6_address_count = 1
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
   key_name                    = var.aws_key_name
   associate_public_ip_address = true
   ebs_optimized               = true
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_size = var.full-node-config.disk-volume-size
-    volume_type = var.full-node-config.disk-volume-type
-    iops        = 3000
-    throughput  = 250
-  }
+  root_block_device = [
+    {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      volume_size           = module.full-node-config.disk-volume-size
+      volume_type           = module.full-node-config.disk-volume-type
+      throughput            = 250
+      tags                  = {
+        Name = "full-[count.index]-${var.network_name}-root-volume"
+      }
+    }
+  ]
 
   tags = {
     Name       = "${var.network_name}-full-${count.index}"
@@ -161,55 +129,36 @@ resource "aws_instance" "full_node" {
     #aws_nat_gateway.nat_gateway,
     aws_internet_gateway.gw
   ]
-
-  lifecycle {
-
-    ignore_changes = [ami, ipv6_address_count]
-
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait",
-      "sudo apt update -y",
-    ]
-
-    on_failure = continue
-
-  }
-
-  # Setting up the ssh connection
-  connection {
-    type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
-    user        = var.ssh_user
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-
 }
 
+module "rpc_node" {
+  source = "../../terraform/aws/ec2"
 
-resource "aws_instance" "rpc_node" {
-  count              = length(var.aws_region) * var.rpc-node-config.instance-count
+  count              = length(var.aws_region) * module.rpc-node-config.instance-count
   ami                = data.aws_ami.ubuntu_amd64.image_id
-  instance_type      = var.rpc-node-config.instance-type
+  instance_type      = module.rpc-node-config.instance-type
   subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
   availability_zone  = var.azs
-  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ipv6_address_count = 1
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
   key_name                    = var.aws_key_name
   associate_public_ip_address = true
   ebs_optimized               = true
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_size = var.rpc-node-config.disk-volume-size
-    volume_type = var.rpc-node-config.disk-volume-type
-    iops        = 3000
-    throughput  = 250
-  }
+  root_block_device = [
+    {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      volume_size           = module.rpc-node-config.disk-volume-size
+      volume_type           = module.rpc-node-config.disk-volume-type
+      throughput            = 250
+      tags                  = {
+        Name = "rpc-[count.index]-${var.network_name}-root-volume"
+      }
+    }
+  ]
   tags = {
     Name       = "${var.network_name}-rpc-${count.index}"
     name       = "${var.network_name}-rpc-${count.index}"
@@ -224,57 +173,36 @@ resource "aws_instance" "rpc_node" {
     #aws_nat_gateway.nat_gateway,
     aws_internet_gateway.gw
   ]
-
-  lifecycle {
-
-    ignore_changes = [ami, ipv6_address_count]
-
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait",
-      "sudo apt update -y",
-      "sudo DEBIAN_FRONTEND=noninteractive apt-get install curl gnupg openssl net-tools -y",
-    ]
-
-    on_failure = continue
-
-  }
-
-  # Setting up the ssh connection
-  connection {
-    type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
-    user        = var.ssh_user
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-
 }
 
+module "domain_node" {
+  source = "../../terraform/aws/ec2"
 
-resource "aws_instance" "domain_node" {
-  count              = length(var.aws_region) * var.domain-node-config.instance-count
+  count              = length(var.aws_region) * module.domain-node-config.instance-count
   ami                = data.aws_ami.ubuntu_amd64.image_id
-  instance_type      = var.domain-node-config.instance-type
+  instance_type      = module.domain-node-config.instance-type
   subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
   availability_zone  = var.azs
-  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ipv6_address_count = 1
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
   key_name                    = var.aws_key_name
   associate_public_ip_address = true
   ebs_optimized               = true
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_size = var.domain-node-config.disk-volume-size
-    volume_type = var.domain-node-config.disk-volume-type
-    iops        = 3000
-    throughput  = 250
-  }
-
+  root_block_device = [
+    {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      volume_size           = module.domain-node-config.disk-volume-size
+      volume_type           = module.domain-node-config.disk-volume-type
+      throughput            = 250
+      tags                  = {
+        Name = "domain-[count.index]-${var.network_name}-root-volume"
+      }
+    }
+  ]
   tags = {
     Name       = "${var.network_name}-domain-${count.index}"
     name       = "${var.network_name}-domain-${count.index}"
@@ -289,55 +217,36 @@ resource "aws_instance" "domain_node" {
     #aws_nat_gateway.nat_gateway,
     aws_internet_gateway.gw
   ]
-
-  lifecycle {
-
-    ignore_changes = [ami, ipv6_address_count]
-
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait",
-      "sudo apt update -y",
-    ]
-
-    on_failure = continue
-
-  }
-
-  # Setting up the ssh connection
-  connection {
-    type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
-    user        = var.ssh_user
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-
 }
 
+module "farmer_node" {
+  source = "../../terraform/aws/ec2"
 
-resource "aws_instance" "farmer_node" {
-  count              = length(var.aws_region) * var.farmer-node-config.instance-count
+  count              = length(var.aws_region) * module.farmer-node-config.instance-count
   ami                = data.aws_ami.ubuntu_amd64.image_id
-  instance_type      = var.farmer-node-config.instance-type
+  instance_type      = module.farmer-node-config.instance-type
   subnet_id          = element(aws_subnet.public_subnets.*.id, 0)
   availability_zone  = var.azs
-  ipv6_address_count = length(var.aws_region) * var.bootstrap-node-config.instance-count
+  ipv6_address_count = 1
   # Security Group
   vpc_security_group_ids = ["${aws_security_group.network_sg.id}"]
   # the Public SSH key
   key_name                    = var.aws_key_name
   associate_public_ip_address = true
   ebs_optimized               = true
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_size = var.farmer-node-config.disk-volume-size
-    volume_type = var.farmer-node-config.disk-volume-type
-    iops        = 3000
-    throughput  = 250
-  }
+  root_block_device = [
+    {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      volume_size           = module.farmer-node-config.disk-volume-size
+      volume_type           = module.farmer-node-config.disk-volume-type
+      throughput            = 250
+      tags                  = {
+        Name = "farmer-[count.index]-${var.network_name}-root-volume"
+      }
+    }
+  ]
   tags = {
     Name       = "${var.network_name}-farmer-${count.index}"
     name       = "${var.network_name}-farmer-${count.index}"
@@ -352,30 +261,4 @@ resource "aws_instance" "farmer_node" {
     #aws_nat_gateway.nat_gateway,
     aws_internet_gateway.gw
   ]
-
-  lifecycle {
-
-    ignore_changes = [ami, ipv6_address_count]
-
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "cloud-init status --wait",
-      "sudo apt update -y",
-    ]
-
-    on_failure = continue
-
-  }
-
-  # Setting up the ssh connection
-  connection {
-    type        = "ssh"
-    host        = element(self.*.public_ip, count.index)
-    user        = var.ssh_user
-    private_key = file("${var.private_key_path}")
-    timeout     = "300s"
-  }
-
 }

--- a/templates/terraform/network-primitives/outputs.tf
+++ b/templates/terraform/network-primitives/outputs.tf
@@ -1,102 +1,102 @@
 // Output Variables
 
 output "bootstrap_node_server_id" {
-  value = aws_instance.bootstrap_node.*.id
+  value = module.bootstrap_node.*.id
 }
 
 output "bootstrap_node_public_ip" {
-  value = aws_instance.bootstrap_node.*.public_ip
+  value = module.bootstrap_node.*.public_ip
 }
 
 output "bootstrap_node_private_ip" {
-  value = aws_instance.bootstrap_node.*.private_ip
+  value = module.bootstrap_node.*.private_ip
 }
 
 output "bootstrap_node_ami" {
-  value = aws_instance.bootstrap_node.*.ami
+  value = module.bootstrap_node.*.ami
 }
 
 output "bootstrap_node_evm_server_id" {
-  value = aws_instance.bootstrap_node_evm.*.id
+  value = module.bootstrap_node_evm.*.id
 }
 
 output "bootstrap_node_evm_public_ip" {
-  value = aws_instance.bootstrap_node_evm.*.public_ip
+  value = module.bootstrap_node_evm.*.public_ip
 }
 
 output "bootstrap_node_evm_private_ip" {
-  value = aws_instance.bootstrap_node_evm.*.private_ip
+  value = module.bootstrap_node_evm.*.private_ip
 }
 
 output "bootstrap_node_evm_ami" {
-  value = aws_instance.bootstrap_node_evm.*.ami
+  value = module.bootstrap_node_evm.*.ami
 }
 
 output "full_node_server_id" {
-  value = aws_instance.full_node.*.id
+  value = module.full_node.*.id
 }
 
 output "full_node_private_ip" {
-  value = aws_instance.full_node.*.private_ip
+  value = module.full_node.*.private_ip
 }
 
 output "full_node_public_ip" {
-  value = aws_instance.full_node.*.public_ip
+  value = module.full_node.*.public_ip
 }
 
 output "full_node_ami" {
-  value = aws_instance.full_node.*.ami
+  value = module.full_node.*.ami
 }
 
 
 output "rpc_node_server_id" {
-  value = aws_instance.rpc_node.*.id
+  value = module.rpc_node.*.id
 }
 
 output "rpc_node_private_ip" {
-  value = aws_instance.rpc_node.*.private_ip
+  value = module.rpc_node.*.private_ip
 }
 
 output "rpc_node_public_ip" {
-  value = aws_instance.rpc_node.*.public_ip
+  value = module.rpc_node.*.public_ip
 }
 
 output "rpc_node_ami" {
-  value = aws_instance.rpc_node.*.ami
+  value = module.rpc_node.*.ami
 }
 
 
 output "domain_node_server_id" {
-  value = aws_instance.domain_node.*.id
+  value = module.domain_node.*.id
 }
 
 output "domain_node_private_ip" {
-  value = aws_instance.domain_node.*.private_ip
+  value = module.domain_node.*.private_ip
 }
 
 output "domain_node_public_ip" {
-  value = aws_instance.domain_node.*.public_ip
+  value = module.domain_node.*.public_ip
 }
 
 output "domain_node_ami" {
-  value = aws_instance.domain_node.*.ami
+  value = module.domain_node.*.ami
 }
 
 
 output "farmer_node_server_id" {
-  value = aws_instance.farmer_node.*.id
+  value = module.farmer_node.*.id
 }
 
 output "farmer_node_private_ip" {
-  value = aws_instance.farmer_node.*.private_ip
+  value = module.farmer_node.*.private_ip
 }
 
 output "farmer_node_public_ip" {
-  value = aws_instance.farmer_node.*.public_ip
+  value = module.farmer_node.*.public_ip
 }
 
 output "farmer_node_ami" {
-  value = aws_instance.farmer_node.*.ami
+  value = module.farmer_node.*.ami
 }
 
 output "dns-records" {


### PR DESCRIPTION
This PR extends the AWS EC2 module by moving the lifecycle and remote provisioner blocks from the network primitives resources to the module itself.

The resources are now converted to modules which use the `templates/terraform/aws/ec2` root module.

closes #142 