### PR TITLE
Fixes nginx conf to be reusable by squid modules

### DIFF
--- a/templates/terraform/explorer/base/config/nginx-squid.conf
+++ b/templates/terraform/explorer/base/config/nginx-squid.conf
@@ -2,49 +2,7 @@ server {
     root /var/www/html;
     index index.html index.htm index.nginx-debian.html;
 
-    server_name squid.gemini-3h.subspace.network;
-
-    location ~* \.(?:css|js|json)$ {
-        try_files $uri $uri/ @backend;
-    }
-
-    location @backend {
-        proxy_pass http://127.0.0.1:4350;
-    }
-
-    location /graphql {
-        proxy_buffering off;
-        proxy_pass http://127.0.0.1:4350/graphql;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_http_version 1.1;
-    }
-
-    location /db-health {
-        proxy_buffering off;
-        proxy_pass http://127.0.0.1:8080/health;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_http_version 1.1;
-    }
-
-    location /processor-health {
-        proxy_buffering off;
-        proxy_pass http://127.0.0.1:7070/health;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_http_version 1.1;
-    }
-}
-
-server {
-    root /var/www/html;
-    index index.html index.htm index.nginx-debian.html;
-
-    server_name nova.squid.gemini-3h.subspace.network;
+    server_name _;
 
     location ~* \.(?:css|js|json)$ {
         try_files $uri $uri/ @backend;


### PR DESCRIPTION
Each squid module will create it's own `server_name` directive now. This makes the config reusable by multiple squid modules for different networks.

closes #142 