### PR TITLE
Upgrade gemini 3h

### DIFF
--- a/aws/gemini-3h/main.tf
+++ b/aws/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-11"
+    docker-tag         = "gemini-3h-2024-mar-14"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-11"
+    docker-tag         = "gemini-3h-2024-mar-14"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-11"
+    docker-tag         = "gemini-3h-2024-mar-14"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-11"
+    docker-tag         = "gemini-3h-2024-mar-14"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-11"
+    docker-tag         = "gemini-3h-2024-mar-14"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-mar-11"
+    docker-tag             = "gemini-3h-2024-mar-14"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"

--- a/aws/gemini-3h/main.tf
+++ b/aws/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-14"
+    docker-tag         = "gemini-3h-2024-mar-18"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-14"
+    docker-tag         = "gemini-3h-2024-mar-18"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-14"
+    docker-tag         = "gemini-3h-2024-mar-18"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-14"
+    docker-tag         = "gemini-3h-2024-mar-18"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-mar-14"
+    docker-tag         = "gemini-3h-2024-mar-18"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-mar-14"
+    docker-tag             = "gemini-3h-2024-mar-18"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"


### PR DESCRIPTION
## **User description**
1. bump gemini-3h release to mar-14
2. bump gemini-3h release to mar-18


___

## **Type**
enhancement


___

## **Description**
- Updated the Docker tag in the Gemini-3h Terraform configuration to "gemini-3h-2024-mar-18" across multiple instance types (bootstrap, evm_bootstrap, full, rpc, domain, farmer). This ensures the deployment uses the latest Docker image.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update Docker Tag for Gemini-3h Deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aws/gemini-3h/main.tf
<li>Updated <code>docker-tag</code> for various instance types from <br>"gemini-3h-2024-mar-11" to "gemini-3h-2024-mar-18".<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/288/files#diff-3b7afab743a8ac1f8a135884fcdd27a3f4f1043827878079cdd906fac167dc40">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

