### PR TITLE
Explorer terraform minor fixes

### DIFF
--- a/explorer/terraform/aws/gemini-3g/main.tf
+++ b/explorer/terraform/aws/gemini-3g/main.tf
@@ -68,7 +68,7 @@ module "squids" {
     network-name       = "${var.network_name}"
     domain-prefix      = "archive"
     node-org           = "subspace"
-    node-tag           = "gemini-3g-nov-19"
+    node-tag           = var.node_tag
     docker-tag         = "latest"
     instance-type      = var.instance_type
     deployment-version = 0
@@ -83,7 +83,7 @@ module "squids" {
     network-name       = "${var.network_name}"
     domain-prefix      = "nova.archive"
     node-org           = "subspace"
-    node-tag           = "gemini-3g-nov-19"
+    node-tag           = var.node_tag
     docker-tag         = "evm-domain"
     instance-type      = var.instance_type
     deployment-version = 0

--- a/explorer/terraform/aws/gemini-3g/variables.tf
+++ b/explorer/terraform/aws/gemini-3g/variables.tf
@@ -4,6 +4,10 @@ variable "netdata_token" {
 
 }
 
+variable "node_tag" {
+  type = string
+}
+
 variable "nr_api_key" {
   description = "New relic API Key"
   type        = string

--- a/explorer/terraform/aws/gemini-3h/main.tf
+++ b/explorer/terraform/aws/gemini-3h/main.tf
@@ -27,7 +27,7 @@ module "squids" {
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region
-    instance-count-green = 0# var.instance_count_green
+    instance-count-green = 0 # var.instance_count_green
     disk-volume-size     = var.disk_volume_size
     disk-volume-type     = var.disk_volume_type
     prune                = false
@@ -68,7 +68,7 @@ module "squids" {
     network-name       = "${var.network_name}"
     domain-prefix      = "archive"
     node-org           = "subspace"
-    node-tag           = "gemini-3h-2024-feb-19"
+    node-tag           = var.node_tag
     docker-tag         = "latest"
     instance-type      = var.instance_type
     deployment-version = 0
@@ -83,7 +83,7 @@ module "squids" {
     network-name       = "${var.network_name}"
     domain-prefix      = "nova.archive"
     node-org           = "subspace"
-    node-tag           = "gemini-3h-2024-feb-19"
+    node-tag           = var.node_tag
     docker-tag         = "latest"
     instance-type      = var.instance_type
     deployment-version = 0

--- a/explorer/terraform/aws/gemini-3h/main.tf
+++ b/explorer/terraform/aws/gemini-3h/main.tf
@@ -27,7 +27,7 @@ module "squids" {
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region
-    instance-count-green = 0 # var.instance_count_green
+    instance-count-green = var.instance_count_green
     disk-volume-size     = var.disk_volume_size
     disk-volume-type     = var.disk_volume_type
     prune                = false
@@ -57,7 +57,7 @@ module "squids" {
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region
-    instance-count-green = var.instance_count_green
+    instance-count-green = 0 #var.instance_count_green
     disk-volume-size     = var.disk_volume_size
     disk-volume-type     = var.disk_volume_type
     prune                = false

--- a/explorer/terraform/aws/gemini-3h/variables.tf
+++ b/explorer/terraform/aws/gemini-3h/variables.tf
@@ -4,6 +4,10 @@ variable "netdata_token" {
 
 }
 
+variable "node_tag" {
+  type = string
+}
+
 variable "nr_api_key" {
   description = "New relic API Key"
   type        = string

--- a/templates/terraform/explorer/base/archive.tf
+++ b/templates/terraform/explorer/base/archive.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "archive_node" {
 
   lifecycle {
 
-    ignore_changes = [ ami ]
+    ignore_changes = [ami, instance_type]
 
   }
 
@@ -105,7 +105,7 @@ resource "aws_instance" "nova_archive_node" {
 
   lifecycle {
 
-    ignore_changes = [ ami ]
+    ignore_changes = [ami, instance_type]
 
   }
 

--- a/templates/terraform/explorer/base/network.tf
+++ b/templates/terraform/explorer/base/network.tf
@@ -1,9 +1,10 @@
-resource "aws_vpc" "gemini-3h-squid-vpc" {
+resource "aws_vpc" "gemini-squid-vpc" {
   cidr_block           = var.vpc_cidr_block
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
+    Name = "${var.network_name}-squid-vpc"
     name = "${var.network_name}-squid-vpc"
   }
 }
@@ -11,7 +12,7 @@ resource "aws_vpc" "gemini-3h-squid-vpc" {
 
 resource "aws_subnet" "public_subnets" {
   count                   = length(var.public_subnet_cidrs)
-  vpc_id                  = aws_vpc.gemini-3h-squid-vpc.id
+  vpc_id                  = aws_vpc.gemini-squid-vpc.id
   cidr_block              = element(var.public_subnet_cidrs, count.index)
   availability_zone       = element(var.azs, count.index)
   map_public_ip_on_launch = "true"
@@ -24,7 +25,7 @@ resource "aws_subnet" "public_subnets" {
 
 resource "aws_internet_gateway" "squid-gw" {
   count  = length(var.public_subnet_cidrs)
-  vpc_id = aws_vpc.gemini-3h-squid-vpc.id
+  vpc_id = aws_vpc.gemini-squid-vpc.id
 
   tags = {
     Name = "${var.network_name}-squid-gw-public-subnet-${count.index}"
@@ -38,7 +39,7 @@ resource "aws_internet_gateway" "squid-gw" {
 
 resource "aws_route_table" "public_route_table" {
   count  = length(var.public_subnet_cidrs)
-  vpc_id = aws_vpc.gemini-3h-squid-vpc.id
+  vpc_id = aws_vpc.gemini-squid-vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -68,7 +69,7 @@ resource "aws_route_table_association" "public_route_table_subnets_association" 
 resource "aws_security_group" "gemini-squid-sg" {
   name        = "${var.network_name}-squid-sg"
   description = "Allow HTTP and HTTPS inbound traffic"
-  vpc_id      = aws_vpc.gemini-3h-squid-vpc.id
+  vpc_id      = aws_vpc.gemini-squid-vpc.id
 
   ingress {
     description = "HTTPS for VPC"
@@ -107,6 +108,6 @@ resource "aws_security_group" "gemini-squid-sg" {
   }
 
   depends_on = [
-    aws_vpc.gemini-3h-squid-vpc
+    aws_vpc.gemini-squid-vpc
   ]
 }


### PR DESCRIPTION
## **User description**
The PR just makes some basic adjustments by adding a node_tag variable for network releases and makes the VPC reusable as a module by giving a generic name.

Changes:
- add node-tag variable
- make VPC reusable for all networks
- change lifecycle for archive squids


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new Terraform variable `node_tag` to dynamically set node tags for different network deployments.
- Renamed AWS VPC and related resources in Terraform configuration for generic use across different networks, enhancing reusability.
- Added a dynamic `Name` tag to the VPC resource to better reflect the network name in AWS console.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Use Variable for Node Tag in Terraform Config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/terraform/aws/gemini-3g/main.tf
<li>Replaced hard-coded <code>node-tag</code> values with a variable <code>node_tag</code> for both <br><code>squids</code> and <code>nova-archive-node-config</code>.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/290/files#diff-a2e586d879346628ed491984ee8d372a1dceda8dc4f8896d8af8c149b9cea15a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Introduce Node Tag Variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/terraform/aws/gemini-3g/variables.tf
- Introduced a new variable `node_tag` of type string.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/290/files#diff-cd0285efe7ff77dbe417ff3e03a0f936a6e7ec8836efca4bf8e70ce3a4e88243">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network.tf</strong><dd><code>Make VPC Reusable and Rename for Generic Use</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/explorer/base/network.tf
<li>Renamed AWS VPC resource for generic use across networks.<br> <li> Updated references to the renamed VPC in related resources (subnets, <br>internet gateway, route table, security group).<br> <li> Added a dynamic <code>Name</code> tag to the VPC resource to reflect the network <br>name.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/290/files#diff-767dc526931198eeb2c67d068ec21a6e702cbee3fdb44bd634f275ae7b89ff4d">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

