### PR TITLE
update block explorer DNS records

### DIFF
--- a/dns/records.tf
+++ b/dns/records.tf
@@ -114,9 +114,21 @@ resource "cloudflare_record" "block_explorer" {
   proxied = false
   ttl     = 3600
   type    = "CNAME"
-  value   = "subspace.github.io"
+  value   = "astral-prod.netlify.app"
   zone_id = data.cloudflare_zone.subspace_network.id
 }
+
+// subspace block explorer Astral
+resource "cloudflare_record" "block_explorer_astral" {
+  comment = "Subspace block explorer"
+  name    = "astral"
+  proxied = false
+  ttl     = 3600
+  type    = "CNAME"
+  value   = "astral-prod.netlify.app"
+  zone_id = data.cloudflare_zone.subspace_network.id
+}
+
 
 // subspace telemetry
 resource "cloudflare_record" "telemetry" {


### PR DESCRIPTION
## **User description**
This PR updates the DNS records for block explorer from github hosted pages to netlify. 

Additions:
- add astral cname record pointing to same netlify endpoint


___

## **Type**
enhancement


___

## **Description**
- Updated DNS CNAME record for the block explorer to point to Netlify (`astral-prod.netlify.app`), moving away from GitHub Pages.
- Added a new DNS CNAME record for the `astral` subdomain, also pointing to the Netlify endpoint (`astral-prod.netlify.app`). This enhances the DNS configuration for better management and future scalability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>records.tf</strong><dd><code>Update Block Explorer DNS and Add Astral CNAME Record</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dns/records.tf
<li>Updated the CNAME record for the block explorer to point to <br><code>astral-prod.netlify.app</code> instead of <code>subspace.github.io</code>.<br> <li> Added a new CNAME record for the <code>astral</code> subdomain pointing to <br><code>astral-prod.netlify.app</code>.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/294/files#diff-5b5a561d2c96085585021576b23185ad480837460bd330bd915d114ded4414fe">+13/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

