### PR TITLE
add automation scripts to generate node keys

### DIFF
--- a/scripts/generate_node_keys.sh
+++ b/scripts/generate_node_keys.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Function to check if subkey is installed
+check_subkey() {
+  if ! command -v subkey &> /dev/null; then
+    echo "subkey not found. Installing..."
+    curl https://getsubstrate.io -sSf | bash -s -- --fast
+    cargo install --force subkey --git https://github.com/paritytech/substrate --locked
+  else
+    echo "subkey is already installed."
+  fi
+}
+
+# Function to generate node key and store in a file
+# Generate node key and store in a file
+generate_node_key() {
+  local node_type=$1
+  local node_index=$2
+
+  local key_file="${node_type}-${node_index}.key"
+  subkey generate-node-key 2>&1 | tee "${key_file}"
+  echo "Generated node key for ${node_type}-${node_index}"
+}
+
+# Function to add key-value pair to Hashicorp Vault
+add_to_vault() {
+  local key_file=$1
+
+  local key_id=$(sed -n '1p' "${key_file}")
+  local key_value=$(sed -n '2p' "${key_file}")
+  local node_name=$(basename "${key_file}" .key)
+
+  # Add key-value pair to Hashicorp Vault using API call
+  local vault_endpoint="https://vault.eks.subspace.network/v1/secret/data/node-keys/${node_name}"
+  local vault_token=$(base64 -d <<< ${VAULT_TOKEN})
+
+  curl -X POST -H "X-Vault-Token: ${vault_token}" -d "{\"data\": {\"key\": \"${key_id}=${key_value}\"}}" "${vault_endpoint}"
+  echo "Added key-value pair to Hashicorp Vault: ${node_name} = ${key_id}=${key_value}"
+}
+
+# Check and install subkey if needed
+check_subkey
+
+# Generate node keys for bootstrap nodes
+for i in {0..1}; do
+  generate_node_key "bootstrap" "${i}"
+done
+
+# Generate node keys for rpc nodes
+for i in {0..1}; do
+  generate_node_key "rpc" "${i}"
+done
+
+# Generate node keys for domain nodes
+for i in {0..1}; do
+  generate_node_key "domain" "${i}"
+done
+
+# Generate node key for farmer node
+generate_node_key "farmer" "0"
+
+# Generate node keys for nova-bootstrap nodes
+for i in {0..1}; do
+  generate_node_key "nova-bootstrap" "${i}"
+done
+
+# Add generated keys to Hashicorp Vault
+for key_file in *.key; do
+  add_to_vault "${key_file}"
+done
+
+echo "Node key generation and Vault storage completed."

--- a/scripts/restore_node_keys.sh
+++ b/scripts/restore_node_keys.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Check if jq is installed and install it if not.
+check_jq() {
+  if ! command -v jq &> /dev/null; then
+    echo "jq not found. Installing..."
+    sudo apt-get update
+    sudo apt-get install -y jq
+  else
+    echo "jq is already installed."
+  fi
+}
+
+# Function to retrieve key-value pair from Hashicorp Vault
+get_from_vault() {
+  local node_name=$1
+
+  local vault_endpoint="https://vault.eks.subspace.network/v1/secret/data/node-keys/${node_name}"
+  local vault_token=$(base64 -d <<< ${VAULT_TOKEN})
+
+  local response=$(curl -s -H "X-Vault-Token: ${vault_token}" "${vault_endpoint}")
+  local key_value=$(echo "${response}" | jq -r '.data.data.key')
+
+  echo "Retrieved key-value pair from Hashicorp Vault for node: ${node_name}"
+  echo "${key_value}"
+}
+
+# Function to store key-value pair in .env file
+store_in_env_file() {
+  local node_name=$1
+  local key_id=$2
+  local key_value=$3
+
+  echo "${node_id}=${node_name}" >> ".env"
+  echo "peer_id=${key_id}" >> ".env"
+  echo "node_key=${key_value}" >> ".env"
+
+  echo "Stored key-value pair in .env file for node: ${node_name}"
+}
+
+# Check if node name is provided as an argument
+if [ $# -eq 0 ]; then
+  echo "Please provide the node name as an argument."
+  exit 1
+fi
+
+node_name=$1
+
+# Check and install jq if needed
+check_jq
+
+# Retrieve key-value pair from Hashicorp Vault
+key_value=$(get_from_vault "${node_name}")
+
+# Extract key_id and key_value from the retrieved key-value pair
+key_id=$(echo "${key_value}" | awk -F'=' '{print $1}')
+key_value=$(echo "${key_value}" | awk -F'=' '{print $2}')
+
+# Store key_id and key_value in .env file
+store_in_env_file "${node_name}" "${key_id}" "${key_value}"
+
+echo "Key-value pair retrieval and storage completed for node: ${node_name}"


### PR DESCRIPTION
## **User description**
We currently generate node keys manually, and store in flat files which is cumbersome especially as the network expands.

These scripts do the following:
- generates keys with subkey and stores in hashicorp vault
- restores keys and adds to .env file to be used as part of automation with ansible and terraform


___

## **Type**
enhancement


___

## **Description**
- Introduced two new automation scripts for node key management:
  - `generate_node_keys.sh` for generating and storing node keys in Hashicorp Vault.
  - `restore_node_keys.sh` for retrieving node keys from Hashicorp Vault and storing them in a `.env` file.
- These scripts facilitate the automation of node key generation, storage, and retrieval, enhancing the deployment process for various node types.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_node_keys.sh</strong><dd><code>Automate Node Key Generation and Storage in Hashicorp Vault</code></dd></summary>
<hr>

scripts/generate_node_keys.sh
<li>Added a script to automate the generation of node keys using <code>subkey</code> <br>and store them in Hashicorp Vault.<br> <li> Implemented functions to check for <code>subkey</code> installation, generate node <br>keys, and add them to Hashicorp Vault.<br> <li> Automated node key generation for various node types (bootstrap, rpc, <br>domain, farmer, nova-bootstrap).


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/299/files#diff-c93f6283d6b699f02daba82e8259ddbbe11e2356b85438284b9bb5149dee7d56">+72/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>restore_node_keys.sh</strong><dd><code>Automate Restoration of Node Keys from Hashicorp Vault</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/restore_node_keys.sh
<li>Added a script to restore node keys from Hashicorp Vault and store <br>them in a <code>.env</code> file.<br> <li> Implemented functions to check for <code>jq</code> installation, retrieve key-value <br>pairs from Hashicorp Vault, and store them in <code>.env</code> file.<br> <li> Ensured the script exits if no node name is provided as an argument.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/299/files#diff-4cd0e4d54eda3f354b91149b7f36a906c7c196b2c0e37d11c13059121d899e93">+60/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

