### PR TITLE
Hetzner module

### DIFF
--- a/resources/hetzner/backend.tf
+++ b/resources/hetzner/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "subspace-sre"
+
+    workspaces {
+      name = "ephemeral-devnet-hetzner"
+    }
+  }
+}

--- a/resources/hetzner/backend.tf
+++ b/resources/hetzner/backend.tf
@@ -3,7 +3,7 @@ terraform {
     organization = "subspace-sre"
 
     workspaces {
-      name = "ephemeral-devnet-hetzner"
+      name = var.workspace_name
     }
   }
 }

--- a/resources/hetzner/main.tf
+++ b/resources/hetzner/main.tf
@@ -1,0 +1,84 @@
+module "network" {
+  source          = "../../templates/terraform/hetzner"
+  path_to_scripts = "../../templates/scripts"
+  network_name    = var.network_name
+
+  bootstrap-node-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["bootstrap"]
+    repo-org            = "subspace"
+    node-tag            = "bootstrap-node"
+    additional-node-ips = var.additional_node_ips["bootstrap"]
+    reserved-only       = true
+    prune               = false
+    genesis-hash        = var.genesis_hash
+    dsn-listen-port     = 30533
+    node-dsn-port       = 30433
+  }
+
+  bootstrap-node-evm-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["bootstrap"]
+    repo-org            = "subspace"
+    node-tag            = "bootstrap-node"
+    additional-node-ips = var.additional_node_ips["bootstrap"]
+    reserved-only       = true
+    prune               = false
+    genesis-hash        = var.genesis_hash
+    dsn-listen-port     = 30533
+    node-dsn-port       = 30433
+    operator-port       = 30334
+  }
+
+  node-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["node"]
+    repo-org            = "subspace"
+    node-tag            = "subspace-node"
+    additional-node-ips = var.additional_node_ips["node"]
+    reserved-only       = true
+    prune               = false
+    node-dsn-port       = 30433
+  }
+
+  domain-node-config = {
+    deployment-version  = 1
+    instance-count      = var.instance_count["domain"]
+    repo-org            = "subspace"
+    node-tag            = "subspace-node"
+    additional-node-ips = var.additional_node_ips["domain"]
+    domain-prefix       = "domain"
+    reserved-only       = true
+    prune               = false
+    node-dsn-port       = 30433
+    enable-domains      = true
+    domain-id           = var.domain_id
+    domain-labels       = var.domain_labels
+  }
+
+  farmer-node-config = {
+    deployment-version     = 1
+    instance-count         = var.instance_count["farmer"]
+    repo-org               = "subspace"
+    node-tag               = "farmer-node"
+    additional-node-ips    = var.additional_node_ips["farmer"]
+    reserved-only          = true
+    prune                  = false
+    plot-size              = "10G"
+    reward-address         = var.farmer_reward_address
+    force-block-production = true
+    node-dsn-port          = 30433
+
+  }
+
+  tf_token         = var.tf_token
+  private_key_path = var.private_key_path
+  branch_name      = var.branch_name
+  ssh_user         = var.ssh_user
+  genesis_hash     = var.genesis_hash
+}
+
+# External data source to run the shell command and extract the value of the operator bootnode connection parameter
+data "external" "operator_peer_multiaddr" {
+  program = ["bash", "-c", "echo '{\"OPERATOR_MULTI_ADDR\": \"'$(sed -nr 's/^NODE_0_OPERATOR_MULTI_ADDR=(.*)/\\1/p' ./bootstrap_node_evm_keys.txt)'\"}'"]
+}

--- a/resources/hetzner/outputs.tf
+++ b/resources/hetzner/outputs.tf
@@ -1,0 +1,30 @@
+output "bootstrap-node-ipv4-addresses" {
+  value       = module.network.bootstrap-node-ipv4-addresses
+  description = "Bootstrap node IPv4 Addresses"
+}
+
+output "bootstrap-node-evm-ipv4-addresses" {
+  value       = module.network.bootstrap-node-evm-ipv4-addresses
+  description = "Bootstrap node EVM IPv4 Addresses"
+}
+
+output "node-ipv4-addresses" {
+  value       = module.network.node-ipv4-addresses
+  description = "subspace node IPv4 Addresses"
+}
+
+output "domain-node-ipv4-addresses" {
+  value       = module.network.domain-node-ipv4-addresses
+  description = "domain node IPv4 Addresses"
+}
+
+
+output "farmer-nodes-ipv4-addresses" {
+  value       = module.network.farmer-node-ipv4-addresses
+  description = "Farmer node IPv4 Addresses"
+}
+
+# Output the operator_peer_multiaddr value
+output "operator_peer_multiaddr" {
+  value = data.external.operator_peer_multiaddr.result["operator_peer_multiaddr"]
+}

--- a/resources/hetzner/variables.tf
+++ b/resources/hetzner/variables.tf
@@ -1,0 +1,76 @@
+variable "farmer_reward_address" {
+  description = "Farmer's reward address"
+  type        = string
+}
+
+variable "network_name" {
+  description = "Network name"
+  type        = string
+}
+
+//todo change this to a map
+variable "domain_id" {
+  description = "Domain ID"
+  type        = list(number)
+  default     = [0]
+}
+
+//todo change this to a map
+variable "domain_labels" {
+  description = "Tag of the domain to run"
+  type        = list(string)
+  default     = ["evm"]
+}
+
+variable "instance_count" {
+  type = map(number)
+  default = {
+    bootstrap     = 2
+    node          = 1
+    farmer        = 1
+    domain        = 2
+    evm_bootstrap = 1
+  }
+}
+
+variable "additional_node_ips" {
+  type = map(list(string))
+  default = {
+    bootstrap     = [""]
+    node          = [""]
+    farmer        = [""]
+    domain        = [""]
+    evm_bootstrap = [""]
+  }
+}
+
+variable "ssh_user" {
+  type    = string
+  default = "root"
+}
+
+variable "private_key_path" {
+  type    = string
+  default = "~/.ssh/hetzner"
+}
+
+variable "tf_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "branch_name" {
+  description = "name of testing branch"
+  type        = string
+  default     = "main"
+}
+
+variable "genesis_hash" {
+  description = "Genesis hash"
+  type        = string
+}
+
+variable "workspace_name" {
+  description = "Name of the workspace"
+  type        = string
+}

--- a/templates/terraform/hetzner/bootstrap_node_evm_provisioner.tf
+++ b/templates/terraform/hetzner/bootstrap_node_evm_provisioner.tf
@@ -46,7 +46,7 @@ resource "null_resource" "setup-bootstrap-nodes-evm" {
 }
 
 resource "null_resource" "clone_branch" {
-  count = var.branch != "main" ? 1 : 0
+  count = var.branch_name != "main" ? 1 : 0
 
   provisioner "remote-exec" {
     inline = [
@@ -170,7 +170,7 @@ resource "null_resource" "start-bootstrap-nodes-evm" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-evm-config.reserved-only} ${length(local.bootstrap_nodes_evm_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains}",
 
       # start subspace node
-      var.branch != "main" ? join(" && ", [
+      var.branch_name != "main" ? join(" && ", [
         "cp -f /root/subspace/.env /root/subspace/subspace/.env",
         "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d"
       ]) : "sudo docker compose -f /root/subspace/docker-compose.yml up -d"

--- a/templates/terraform/hetzner/bootstrap_node_provisioner.tf
+++ b/templates/terraform/hetzner/bootstrap_node_provisioner.tf
@@ -46,7 +46,7 @@ resource "null_resource" "setup-bootstrap-nodes" {
 }
 
 resource "null_resource" "clone_branch" {
-  count = var.branch != "main" ? 1 : 0
+  count = var.branch_name != "main" ? 1 : 0
 
   provisioner "remote-exec" {
     inline = [
@@ -154,7 +154,7 @@ resource "null_resource" "start-boostrap-nodes" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.bootstrap_nodes_ip_v4)} ${count.index}",
 
       # start subspace node
-      var.branch != "main" ? join(" && ", [
+      var.branch_name != "main" ? join(" && ", [
         "cp -f /root/subspace/.env /root/subspace/subspace/.env",
         "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d"
       ]) : "sudo docker compose -f /root/subspace/docker-compose.yml up -d"

--- a/templates/terraform/hetzner/domain_node_provisioner.tf
+++ b/templates/terraform/hetzner/domain_node_provisioner.tf
@@ -45,7 +45,7 @@ resource "null_resource" "setup-domain-nodes" {
 }
 
 resource "null_resource" "clone_branch" {
-  count = var.branch != "main" ? 1 : 0
+  count = var.branch_name != "main" ? 1 : 0
 
   provisioner "remote-exec" {
     inline = [
@@ -172,7 +172,7 @@ resource "null_resource" "start-domain-nodes" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.domain_node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains} ${var.domain-node-config.domain-id[0]}",
 
       # start subspace node
-      var.branch != "main" ? join(" && ", [
+      var.branch_name != "main" ? join(" && ", [
         "cp -f /root/subspace/.env /root/subspace/subspace/.env",
         "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d"
       ]) : "sudo docker compose -f /root/subspace/docker-compose.yml up -d"

--- a/templates/terraform/hetzner/farmer_node_provisioner.tf
+++ b/templates/terraform/hetzner/farmer_node_provisioner.tf
@@ -48,7 +48,7 @@ resource "null_resource" "setup-farmer-nodes" {
 }
 
 resource "null_resource" "clone_branch" {
-  count = var.branch != "main" ? 1 : 0
+  count = var.branch_name != "main" ? 1 : 0
 
   provisioner "remote-exec" {
     inline = [
@@ -160,7 +160,7 @@ resource "null_resource" "start-farmer-nodes" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
 
       # start subspace node
-      var.branch != "main" ? join(" && ", [
+      var.branch_name != "main" ? join(" && ", [
         "cp -f /root/subspace/.env /root/subspace/subspace/.env",
         "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d"
       ]) : "sudo docker compose -f /root/subspace/docker-compose.yml up -d"

--- a/templates/terraform/hetzner/farmer_node_provisioner.tf
+++ b/templates/terraform/hetzner/farmer_node_provisioner.tf
@@ -45,8 +45,11 @@ resource "null_resource" "setup-farmer-nodes" {
       "sudo /root/subspace/installer.sh",
     ]
   }
+}
 
-  # clone testing branch
+resource "null_resource" "clone_branch" {
+  count = var.branch != "main" ? 1 : 0
+
   provisioner "remote-exec" {
     inline = [
       "cd /root/subspace/",
@@ -55,7 +58,6 @@ resource "null_resource" "setup-farmer-nodes" {
       "git checkout ${var.branch_name}"
     ]
   }
-
 }
 
 resource "null_resource" "prune-farmer-nodes" {
@@ -152,14 +154,16 @@ resource "null_resource" "start-farmer-nodes" {
       "echo PLOT_SIZE=${var.farmer-node-config.plot-size} >> /root/subspace/.env",
       "echo PIECE_CACHE_SIZE=${var.piece_cache_size} >> /root/subspace/.env",
       "echo NODE_DSN_PORT=${var.farmer-node-config.node-dsn-port} >> /root/subspace/.env",
+      "echo BRANCH_NAME=${var.branch_name} >> /root/subspace/.env",
 
       # create docker compose file
-      "chmod +x /root/subspace/create_compose_file.sh",
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.farmer_node_ipv4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.farmer-node-config.force-block-production}",
 
-      # start subspace
-      "cp -f /root/subspace/.env /root/subspace/subspace/.env",
-      "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d",
+      # start subspace node
+      var.branch != "main" ? join(" && ", [
+        "cp -f /root/subspace/.env /root/subspace/subspace/.env",
+        "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d"
+      ]) : "sudo docker compose -f /root/subspace/docker-compose.yml up -d"
     ]
   }
 }

--- a/templates/terraform/hetzner/node_provisioner.tf
+++ b/templates/terraform/hetzner/node_provisioner.tf
@@ -46,7 +46,7 @@ resource "null_resource" "setup-nodes" {
 }
 
 resource "null_resource" "clone_branch" {
-  count = var.branch != "main" ? 1 : 0
+  count = var.branch_name != "main" ? 1 : 0
 
   provisioner "remote-exec" {
     inline = [
@@ -156,7 +156,7 @@ resource "null_resource" "start-nodes" {
       "bash /root/subspace/create_compose_file.sh ${var.bootstrap-node-config.reserved-only} ${length(local.node_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)}",
 
       # start subspace node
-      var.branch != "main" ? join(" && ", [
+      var.branch_name != "main" ? join(" && ", [
         "cp -f /root/subspace/.env /root/subspace/subspace/.env",
         "sudo docker compose -f /root/subspace/subspace/docker-compose.yml up -d"
       ]) : "sudo docker compose -f /root/subspace/docker-compose.yml up -d"

--- a/testing-framework/hetzner/network/main.tf
+++ b/testing-framework/hetzner/network/main.tf
@@ -1,6 +1,6 @@
 module "network" {
   source          = "../../../templates/terraform/hetzner"
-  path_to_scripts = "../../../templates/scripts"
+  path_to_scripts = "./scripts"
   network_name    = var.network_name
 
   bootstrap-node-config = {

--- a/testing-framework/hetzner/network/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_bootstrap_node_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
-EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP=$(curl -s -4 https://ifconfig.me)
 
 reserved_only=${1}
 node_count=${2}

--- a/testing-framework/hetzner/network/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_bootstrap_node_compose_file.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+
+cat > ~/subspace/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+
+services:
+  dsn-bootstrap-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-bootstrap-node
+    image: \${REPO_ORG}/\${NODE_TAG}:latest
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=info
+    ports:
+      - "30533:30533"
+    command:
+      - start
+      - "--keypair"
+      - \${DSN_NODE_KEY}
+      - "--listen-on"
+      - /ip4/0.0.0.0/udp/30533/quic-v1
+      - "--listen-on"
+      - /ip4/0.0.0.0/tcp/30533
+      - --protocol-version
+      - \${GENESIS_HASH}
+      - "--in-peers"
+      - "1000"
+      - "--out-peers"
+      - "1000"
+      - "--pending-in-peers"
+      - "1000"
+      - "--pending-out-peers"
+      - "1000"
+      - "--external-address"
+## comment to disable external addresses using IP format for now
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/tcp/30533"
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--reserved-peers\"" >> ~/subspace/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/subspace/docker-compose.yml
+    echo "      - \"--bootstrap-nodes\"" >> ~/subspace/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/subspace/docker-compose.yml
+  fi
+done
+
+cat >> ~/subspace/subspace/docker-compose.yml << EOF
+  archival-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${REPO_ORG}/node:latest
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30433:30433/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/tcp"
+      - "9615:9615"
+    command: [
+      "run",
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+      "--prometheus-listen-on", "0.0.0.0:9615",
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+    echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+    echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  fi
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/subspace/docker-compose.yml

--- a/testing-framework/hetzner/network/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+enable_domains=${5}
+
+cat > ~/subspace/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+
+services:
+  dsn-bootstrap-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-bootstrap-node
+    image: \${REPO_ORG}/\${NODE_TAG}:latest
+    restart: unless-stopped
+    environment:
+      - RUST_LOG=info
+    ports:
+      - "30533:30533"
+    command:
+      - start
+      - "--keypair"
+      - \${DSN_NODE_KEY}
+      - "--listen-on"
+      - /ip4/0.0.0.0/udp/30533/quic-v1
+      - "--listen-on"
+      - /ip4/0.0.0.0/tcp/30533
+      - --protocol-version
+      - \${GENESIS_HASH}
+      - "--in-peers"
+      - "1000"
+      - "--out-peers"
+      - "1000"
+      - "--pending-in-peers"
+      - "1000"
+      - "--pending-out-peers"
+      - "1000"
+## comment to disable external addresses using IP format for now
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/udp/30533/quic-v1"
+#      - "--external-address"
+#      - "/ip4/$EXTERNAL_IP/tcp/30533"
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" != "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--reserved-peers\"" >> ~/subspace/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/subspace/docker-compose.yml
+    echo "      - \"--bootstrap-nodes\"" >> ~/subspace/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/subspace/docker-compose.yml
+  fi
+done
+
+cat >> ~/subspace/subspace/docker-compose.yml << EOF
+  archival-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${REPO_ORG}/node:latest
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30433:30433/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/tcp"
+      - "30334:30334/tcp"
+      - "9615:9615"
+    command: [
+      "run",
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+## comment to disable dsn external addresses using IP format for now
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "1000",
+      "--out-peers", "1000",
+      "--dsn-in-connections", "1000",
+      "--dsn-out-connections", "1000",
+      "--dsn-pending-in-connections", "1000",
+      "--dsn-pending-out-connections", "1000",
+      "--prometheus-listen-on", "0.0.0.0:9615",
+EOF
+
+for (( i = 0; i < node_count; i++ )); do
+  if [ "${current_node}" == "${i}" ]; then
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+    dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+    echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+    echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  fi
+done
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_keys.txt)
+    echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+    echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSPACE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/subspace/docker-compose.yml
+fi
+
+if [ "${enable_domains}" == "true" ]; then
+    {
+    # core domain
+      echo '      "--",'
+      echo '      "--domain-id", "${DOMAIN_ID}",'
+      echo '      "--state-pruning", "archive",'
+      echo '      "--blocks-pruning", "archive",'
+      echo '      "--listen-on", "/ip4/0.0.0.0/tcp/30334",'
+      echo '      "--rpc-cors", "all",'
+      echo '      "--rpc-listen-on", "127.0.0.1:8944",'
+    for (( i = 0; i <  node_count; i++ )); do
+      addr=$(sed -nr "s/NODE_${i}_OPERATOR_MULTI_ADDR=//p" ~/subspace/node_keys.txt)
+      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    done
+
+    }  >> ~/subspace/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/subspace/docker-compose.yml

--- a/testing-framework/hetzner/network/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
-EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP=$(curl -s -4 https://ifconfig.me)
 
 reserved_only=${1}
 node_count=${2}

--- a/testing-framework/hetzner/network/scripts/create_domain_node_compose.file.sh
+++ b/testing-framework/hetzner/network/scripts/create_domain_node_compose.file.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+
+services:
+  archival-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${REPO_ORG}/\${NODE_TAG}:latest
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30433:30433/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/tcp"
+      - "30334:30334"
+      - "9615:9615"
+    command: [
+      "run",
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+## comment to disable dsn external addresses using IP format for now
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+#      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--rpc-max-connections", "10000",
+      "--rpc-cors", "all",
+      "--rpc-listen-on", "0.0.0.0:9944",
+      "--rpc-methods", "safe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+enable_domains=${5}
+domain_id=${6}
+
+for (( i = 0; i < node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+  echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+  dsn_addr=$(sed -nr "s/NODE_${i}_SUBSTRATE_MULTI_ADDR_TCP=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      - \"--dsn-external-address\"" >> ~/subspace/docker-compose.yml
+  echo "      - \"${dsn_addr}\"" >> ~/subspace/docker-compose.yml
+done
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+#// TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == "true" ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/subspace/docker-compose.yml
+fi
+
+if [ "${enable_domains}" == "true" ]; then
+    {
+    # core domain
+    echo '      "--",'
+    echo '      "--domain-id", "${DOMAIN_ID}",'
+    echo '      "--state-pruning", "archive",'
+    echo '      "--blocks-pruning", "archive",'
+    echo '      "--operator-id", "0",'
+    echo '      "--listen-on", "/ip4/0.0.0.0/tcp/30334",'
+    echo '      "--rpc-cors", "all",'
+    echo '      "--rpc-methods", "safe",'
+    echo '      "--rpc-listen-on", "0.0.0.0:8944",'
+
+    for (( i = 0; i < bootstrap_node_evm_count; i++ )); do
+      addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/bootstrap_node_evm_keys.txt)
+      echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+      echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/docker-compose.yml
+    done
+
+    }  >> ~/subspace/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/subspace/docker-compose.yml

--- a/testing-framework/hetzner/network/scripts/create_domain_node_compose.file.sh
+++ b/testing-framework/hetzner/network/scripts/create_domain_node_compose.file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
-EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP=$(curl -s -4 https://ifconfig.me)
 
 cat > ~/subspace/subspace/docker-compose.yml << EOF
 version: "3.7"

--- a/testing-framework/hetzner/network/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_farmer_node_compose_file.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+  farmer_data: {}
+
+services:
+  farmer:
+    depends_on:
+      archival-node:
+        condition: service_healthy
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-farmer
+    image: \${REPO_ORG}/\${NODE_TAG}:latest
+    volumes:
+      - farmer_data:/var/subspace
+    restart: unless-stopped
+    ports:
+      - "30533:30533/udp"
+      - "30533:30533/tcp"
+    command: [
+      "farm", "path=/var/subspace,size=\${PLOT_SIZE}",
+      "--node-rpc-url", "ws://archival-node:9944",
+      "--external-address", "/ip4/$EXTERNAL_IP/udp/30533/quic-v1",
+      "--external-address", "/ip4/$EXTERNAL_IP/tcp/30533",
+      "--listen-on", "/ip4/0.0.0.0/udp/30533/quic-v1",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30533",
+      "--reward-address", "\${REWARD_ADDRESS}",
+      "--metrics-endpoint=0.0.0.0:9616",
+      "--cache-percentage", "15",
+    ]
+
+  archival-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${REPO_ORG}/node:\${NODE_TAG}
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30433:30433/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/tcp"
+      - "9615:9615"
+    command: [
+      "run",
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "256",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+      "--node-key", "\${NODE_KEY}",
+      "--farmer",
+      "--timekeeper",
+      "--rpc-cors", "all",
+      "--rpc-listen-on", "0.0.0.0:9944",
+      "--rpc-methods", "unsafe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+force_block_production=${5}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+  echo "      \"--reserved-only\"," >> ~/subspace/subspace/docker-compose.yml
+fi
+
+if [ "${force_block_production}" == true ]; then
+  echo "      \"--force-synced\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--force-authoring\"," >> ~/subspace/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/subspace/docker-compose.yml

--- a/testing-framework/hetzner/network/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_farmer_node_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
-EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP=$(curl -s -4 https://ifconfig.me)
 
 cat > ~/subspace/subspace/docker-compose.yml << EOF
 version: "3.7"

--- a/testing-framework/hetzner/network/scripts/create_node_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_node_compose_file.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+
+cat > ~/subspace/subspace/docker-compose.yml << EOF
+version: "3.7"
+
+volumes:
+  archival_node_data: {}
+
+services:
+  archival-node:
+    build:
+      context: .
+      dockerfile: $HOME/subspace/subspace/Dockerfile-node
+    image: \${REPO_ORG}/\${NODE_TAG}:latest
+    volumes:
+      - archival_node_data:/var/subspace:rw
+    restart: unless-stopped
+    ports:
+      - "30333:30333/udp"
+      - "30433:30433/udp"
+      - "30333:30333/tcp"
+      - "30433:30433/tcp"
+      - "9615:9615"
+    command: [
+      "run",
+      "--chain", "\${NETWORK_NAME}",
+      "--base-path", "/var/subspace",
+      "--state-pruning", "archive",
+      "--blocks-pruning", "archive",
+      "--listen-on", "/ip4/0.0.0.0/tcp/30333",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/udp/30433/quic-v1",
+      "--dsn-external-address", "/ip4/$EXTERNAL_IP/tcp/30433",
+      "--node-key", "\${NODE_KEY}",
+      "--in-peers", "500",
+      "--out-peers", "250",
+      "--rpc-max-connections", "10000",
+      "--rpc-cors", "all",
+      "--rpc-listen-on", "0.0.0.0:9944",
+      "--rpc-methods", "safe",
+      "--prometheus-listen-on", "0.0.0.0:9615",
+EOF
+
+reserved_only=${1}
+node_count=${2}
+current_node=${3}
+bootstrap_node_count=${4}
+dsn_bootstrap_node_count=${4}
+
+for (( i = 0; i < bootstrap_node_count; i++ )); do
+  addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace//bootstrap_node_keys.txt)
+  echo "      \"--reserved-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--bootstrap-nodes\", \"${addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+# // TODO: make configurable with gemini network as it's not needed for devnet
+for (( i = 0; i < dsn_bootstrap_node_count; i++ )); do
+  dsn_addr=$(sed -nr "s/NODE_${i}_MULTI_ADDR=//p" ~/subspace/dsn_bootstrap_node_keys.txt)
+  echo "      \"--dsn-reserved-peers\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+  echo "      \"--dsn-bootstrap-nodes\", \"${dsn_addr}\"," >> ~/subspace/subspace/docker-compose.yml
+done
+
+if [ "${reserved_only}" == true ]; then
+    echo "      \"--reserved-only\"," >> ~/subspace/subspace/docker-compose.yml
+fi
+
+echo '    ]' >> ~/subspace/subspace/docker-compose.yml

--- a/testing-framework/hetzner/network/scripts/create_node_compose_file.sh
+++ b/testing-framework/hetzner/network/scripts/create_node_compose_file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
-EXTERNAL_IP=`curl -s -4 https://ifconfig.me`
+EXTERNAL_IP=$(curl -s -4 https://ifconfig.me)
 
 cat > ~/subspace/subspace/docker-compose.yml << EOF
 version: "3.7"


### PR DESCRIPTION
This PR improves on #263 and expands by making a general resources module to launch a network from main branch. It also makes the testing framework and main module reuse the `templates/hetzner` root module.

Note for easier reviewing, the commit f0e7f299963efa192f0e800298c65816803b8612 doesn't need to be checked since it restores the scripts deleted in #263 to be used by the testing-framework for devnets.

closes #255 