### PR TITLE
add network L4 loadbalancer (NLB) to cluster and services for TCP/UDP

### DIFF
--- a/eks/eks-blue/nlb.tf
+++ b/eks/eks-blue/nlb.tf
@@ -1,0 +1,183 @@
+resource "aws_lb" "nlb" {
+  name               = "${var.environment_name}-nlb"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = module.eks_cluster.vpc_public_subnets
+
+  tags = {
+    Name = "${var.environment_name}-nlb"
+  }
+}
+
+# Define target groups and listeners for TCP ports
+locals {
+  tcp_ports = [30333, 30433, 30334, 40333, 30533]
+}
+
+resource "aws_lb_target_group" "tg_tcp" {
+  count = length(local.tcp_ports)
+
+  name     = "${var.environment_name}-tg-tcp-${local.tcp_ports[count.index]}"
+  port     = local.tcp_ports[count.index]
+  protocol = "TCP"
+  vpc_id   = module.eks_cluster.vpc_id
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    port                = local.tcp_ports[count.index] # Use the same port for health checks
+    protocol            = "TCP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name = "${var.environment_name}-tg-tcp-${local.tcp_ports[count.index]}"
+  }
+}
+
+resource "aws_lb_listener" "nlb_listener_tcp" {
+  count = length(local.tcp_ports)
+
+  load_balancer_arn = aws_lb.nlb.arn
+  port              = local.tcp_ports[count.index]
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg_tcp[count.index].arn
+  }
+}
+
+# Define target groups and listeners for UDP ports
+locals {
+  udp_ports = [30333, 30433, 30334, 30533]
+}
+
+resource "aws_lb_target_group" "tg_udp" {
+  count = length(local.udp_ports)
+
+  name     = "${var.environment_name}-tg-udp-${local.udp_ports[count.index]}"
+  port     = local.udp_ports[count.index]
+  protocol = "UDP"
+  vpc_id   = module.eks_cluster.vpc_id
+
+  health_check {
+    enabled = false # UDP health checks are not supported
+  }
+
+  tags = {
+    Name = "${var.environment_name}-tg-udp-${local.udp_ports[count.index]}"
+  }
+}
+
+resource "aws_lb_listener" "nlb_listener_udp" {
+  count = length(local.udp_ports)
+
+  load_balancer_arn = aws_lb.nlb.arn
+  port              = local.udp_ports[count.index]
+  protocol          = "UDP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg_udp[count.index].arn
+  }
+}
+
+# Define security group rules for EKS cluster
+resource "aws_security_group" "eks_security_group_network" {
+  name        = "${var.environment_name}-eks-sg-network"
+  description = "Security group for EKS cluster"
+  vpc_id      = module.eks_cluster.vpc_id
+
+  ingress {
+    description      = "Node Port 30333 for VPC"
+    from_port        = 30333
+    to_port          = 30333
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node Port 30433 for VPC"
+    from_port        = 30433
+    to_port          = 30433
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node Port 30334 Domain port for VPC"
+    from_port        = 30334
+    to_port          = 30334
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Domain Operator Node Port 40333 for VPC"
+    from_port        = 40333
+    to_port          = 40333
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Farmer Port 30533 for VPC"
+    from_port        = 30533
+    to_port          = 30533
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node UDP Port 30333 for VPC"
+    from_port        = 30333
+    to_port          = 30333
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node UDP Port 30433 for VPC"
+    from_port        = 30433
+    to_port          = 30433
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node UDP Port 30334 Domain port for VPC"
+    from_port        = 30334
+    to_port          = 30334
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Farmer UDP Port 30533 for VPC"
+    from_port        = 30533
+    to_port          = 30533
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    description      = "egress for VPC"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}

--- a/eks/eks-green/nlb.tf
+++ b/eks/eks-green/nlb.tf
@@ -1,0 +1,183 @@
+resource "aws_lb" "nlb" {
+  name               = "${var.environment_name}-nlb"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = module.eks_cluster.vpc_public_subnets
+
+  tags = {
+    Name = "${var.environment_name}-nlb"
+  }
+}
+
+# Define target groups and listeners for TCP ports
+locals {
+  tcp_ports = [30333, 30433, 30334, 40333, 30533]
+}
+
+resource "aws_lb_target_group" "tg_tcp" {
+  count = length(local.tcp_ports)
+
+  name     = "${var.environment_name}-tg-tcp-${local.tcp_ports[count.index]}"
+  port     = local.tcp_ports[count.index]
+  protocol = "TCP"
+  vpc_id   = module.eks_cluster.vpc_id
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    port                = local.tcp_ports[count.index] # Use the same port for health checks
+    protocol            = "TCP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name = "${var.environment_name}-tg-tcp-${local.tcp_ports[count.index]}"
+  }
+}
+
+resource "aws_lb_listener" "nlb_listener_tcp" {
+  count = length(local.tcp_ports)
+
+  load_balancer_arn = aws_lb.nlb.arn
+  port              = local.tcp_ports[count.index]
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg_tcp[count.index].arn
+  }
+}
+
+# Define target groups and listeners for UDP ports
+locals {
+  udp_ports = [30333, 30433, 30334, 30533]
+}
+
+resource "aws_lb_target_group" "tg_udp" {
+  count = length(local.udp_ports)
+
+  name     = "${var.environment_name}-tg-udp-${local.udp_ports[count.index]}"
+  port     = local.udp_ports[count.index]
+  protocol = "UDP"
+  vpc_id   = module.eks_cluster.vpc_id
+
+  health_check {
+    enabled = false # UDP health checks are not supported
+  }
+
+  tags = {
+    Name = "${var.environment_name}-tg-udp-${local.udp_ports[count.index]}"
+  }
+}
+
+resource "aws_lb_listener" "nlb_listener_udp" {
+  count = length(local.udp_ports)
+
+  load_balancer_arn = aws_lb.nlb.arn
+  port              = local.udp_ports[count.index]
+  protocol          = "UDP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg_udp[count.index].arn
+  }
+}
+
+# Define security group rules for EKS cluster
+resource "aws_security_group" "eks_security_group_network" {
+  name        = "${var.environment_name}-eks-sg-network"
+  description = "Security group for EKS cluster"
+  vpc_id      = module.eks_cluster.vpc_id
+
+  ingress {
+    description      = "Node Port 30333 for VPC"
+    from_port        = 30333
+    to_port          = 30333
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node Port 30433 for VPC"
+    from_port        = 30433
+    to_port          = 30433
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node Port 30334 Domain port for VPC"
+    from_port        = 30334
+    to_port          = 30334
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Domain Operator Node Port 40333 for VPC"
+    from_port        = 40333
+    to_port          = 40333
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Farmer Port 30533 for VPC"
+    from_port        = 30533
+    to_port          = 30533
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node UDP Port 30333 for VPC"
+    from_port        = 30333
+    to_port          = 30333
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node UDP Port 30433 for VPC"
+    from_port        = 30433
+    to_port          = 30433
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Node UDP Port 30334 Domain port for VPC"
+    from_port        = 30334
+    to_port          = 30334
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Farmer UDP Port 30533 for VPC"
+    from_port        = 30533
+    to_port          = 30533
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    description      = "egress for VPC"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}

--- a/kubernetes/devnet/base/bootstrap-domain-node/archival-node-service.yaml
+++ b/kubernetes/devnet/base/bootstrap-domain-node/archival-node-service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: boostrap-domain-node-service
   namespace: bootstrap-domain
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
 spec:
   selector:
     app: domain-node
@@ -44,4 +47,4 @@ spec:
     protocol: TCP
     port: 9616
     targetPort: 9616
-  type: ClusterIP
+  type: LoadBalancer

--- a/kubernetes/devnet/base/bootstrap-node/archival-node-configmap.yaml
+++ b/kubernetes/devnet/base/bootstrap-node/archival-node-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: bootstrap-node-config
+  namespace: bootstrap-node
 data:
   NETWORK_NAME: "network-name"
   EXTERNAL_IP: "external-ip"

--- a/kubernetes/devnet/base/bootstrap-node/archival-node-service.yaml
+++ b/kubernetes/devnet/base/bootstrap-node/archival-node-service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: archival-node-service
   namespace: bootstrap-node
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
 spec:
   selector:
     app: archival-node
@@ -36,4 +39,4 @@ spec:
   - protocol: TCP
     port: 9616
     targetPort: 9616
-  type: ClusterIP
+  type: LoadBalancer

--- a/kubernetes/devnet/base/domain-node/archival-node-configmap.yaml
+++ b/kubernetes/devnet/base/domain-node/archival-node-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: domain-node-config
+  namespace: domain-node
 data:
   NETWORK_NAME: "network-name"
   EXTERNAL_IP: "external-ip"

--- a/kubernetes/devnet/base/domain-node/archival-node.yaml
+++ b/kubernetes/devnet/base/domain-node/archival-node.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: domain-node
+  namespace: domain-node
 spec:
   serviceName: "domain-node-service"
   replicas: 1

--- a/kubernetes/devnet/base/domain-node/ingress.yaml
+++ b/kubernetes/devnet/base/domain-node/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: domain-node-ingress
-  namespace: default
+  namespace: domain-node
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/kubernetes/devnet/base/domain-node/pvc.yaml
+++ b/kubernetes/devnet/base/domain-node/pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: domain-node-pvc
-  namespace: default  # Ensure this is set to the namespace where your workload runs
+  namespace: domain-node  # Ensure this is set to the namespace where your workload runs
 spec:
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/devnet/base/domain-node/service.yaml
+++ b/kubernetes/devnet/base/domain-node/service.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: domain-node-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
 spec:
   selector:
     app: domain-node
@@ -33,4 +36,4 @@ spec:
     protocol: TCP
     port: 9615
     targetPort: 9615
-  type: ClusterIP
+  type: LoadBalancer

--- a/kubernetes/devnet/base/farmer/service.yaml
+++ b/kubernetes/devnet/base/farmer/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: farmer-node-service
   namespace: farmer
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
 spec:
   selector:
     app: farmer-node
@@ -43,4 +46,4 @@ spec:
     protocol: TCP
     port: 9616
     targetPort: 9616
-  type: ClusterIP
+  type: LoadBalancer

--- a/kubernetes/devnet/base/rpc-node/service.yaml
+++ b/kubernetes/devnet/base/rpc-node/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: rpc-node-service
   namespace: rpc-node
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
 spec:
   selector:
     app: rpc-node
@@ -35,4 +38,4 @@ spec:
     protocol: TCP
     port: 9615
     targetPort: 9615
-  type: ClusterIP
+  type: LoadBalancer


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added Network Load Balancer (NLB) resources for EKS clusters in both blue and green environments.
- Defined target groups and listeners for TCP and UDP ports.
- Configured security group rules for EKS clusters.
- Updated Kubernetes services to use NLB by adding necessary annotations and changing service types to `LoadBalancer`.
- Added namespaces to various Kubernetes resources for better organization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>nlb.tf</strong><dd><code>Add NLB, target groups, and security group rules for EKS (blue).</code></dd></summary>
<hr>

eks/eks-blue/nlb.tf
<li>Added Network Load Balancer (NLB) resource.<br> <li> Defined target groups and listeners for TCP and UDP ports.<br> <li> Configured security group rules for EKS cluster.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-68204e9ef19a846dccc0136cb0d37bc74545ca75ebd99b3bf9eb7e7d312602ac">+183/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nlb.tf</strong><dd><code>Add NLB, target groups, and security group rules for EKS (green).</code></dd></summary>
<hr>

eks/eks-green/nlb.tf
<li>Added Network Load Balancer (NLB) resource.<br> <li> Defined target groups and listeners for TCP and UDP ports.<br> <li> Configured security group rules for EKS cluster.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-e72eeccadf031718930a0f8187cb7d0a23ffa7ed75185329edde3346548a1e79">+183/-0</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>archival-node-service.yaml</strong><dd><code>Update bootstrap-domain-node service to use NLB.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/bootstrap-domain-node/archival-node-service.yaml
<li>Added annotations for NLB.<br> <li> Changed service type to <code>LoadBalancer</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-426bba379c71565d075374f030fd4551d5fc2284ac912c4e3860cc4ba36de050">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>archival-node-configmap.yaml</strong><dd><code>Add namespace to bootstrap-node ConfigMap.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/bootstrap-node/archival-node-configmap.yaml
- Added namespace to ConfigMap.



</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-456016f1de56afa091aa309d4b720b90212bf0e8c13eda4b9be5225a33db99eb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>archival-node-service.yaml</strong><dd><code>Update bootstrap-node service to use NLB.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/bootstrap-node/archival-node-service.yaml
<li>Added annotations for NLB.<br> <li> Changed service type to <code>LoadBalancer</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-12edc2fe6dec05c41b53db743c5dc9cc41c456d18ff96520c1bc8a75e6c85600">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>archival-node-configmap.yaml</strong><dd><code>Add namespace to domain-node ConfigMap.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/domain-node/archival-node-configmap.yaml
- Added namespace to ConfigMap.



</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-a3075546a418f71719a527d53dc96253890a728604ff8fdef5edc2cd37ef98d5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>archival-node.yaml</strong><dd><code>Add namespace to domain-node StatefulSet.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/domain-node/archival-node.yaml
- Added namespace to StatefulSet.



</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-bec4ea0b73bc4d8504200faf94396b8abdad4a05c1f78e7b0d022761b007ee7a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ingress.yaml</strong><dd><code>Update namespace for domain-node Ingress.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/domain-node/ingress.yaml
- Changed namespace to `domain-node`.



</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-ec1b84f6931fd043490fc82c069fed9898de3233a036faa4787f034a06dbe5f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pvc.yaml</strong><dd><code>Update namespace for domain-node PVC.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/domain-node/pvc.yaml
- Changed namespace to `domain-node`.



</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-4349b7aa8b378520c50fd22a4bcadbdb05cbbcd54896b45783d8a54a626dad40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.yaml</strong><dd><code>Update domain-node service to use NLB.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/domain-node/service.yaml
<li>Added annotations for NLB.<br> <li> Changed service type to <code>LoadBalancer</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-44fd9c98759e9f06238161df924995e02b0e6ac7c0b87e1fba0f06ec4f4296e7">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.yaml</strong><dd><code>Update farmer service to use NLB.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/farmer/service.yaml
<li>Added annotations for NLB.<br> <li> Changed service type to <code>LoadBalancer</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-1ea3656babb5d14fd9219f427797916a69e4189b2d9e05bc267449234ef493f1">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.yaml</strong><dd><code>Update RPC node service to use NLB.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/rpc-node/service.yaml
<li>Added annotations for NLB.<br> <li> Changed service type to <code>LoadBalancer</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/infra/pull/317/files#diff-6f47db6877a21a058978bf7939e3de91f02c80329468dabe302c2795e710827f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

