### PR TITLE
Upgrade gemini 3h

### DIFF
--- a/resources/gemini-3h/main.tf
+++ b/resources/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-11"
+    docker-tag         = "gemini-3h-2024-jun-18"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-11"
+    docker-tag         = "gemini-3h-2024-jun-18"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-11"
+    docker-tag         = "gemini-3h-2024-jun-18"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-11"
+    docker-tag         = "gemini-3h-2024-jun-18"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-11"
+    docker-tag         = "gemini-3h-2024-jun-18"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-jun-11"
+    docker-tag             = "gemini-3h-2024-jun-18"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"

--- a/resources/gemini-3h/main.tf
+++ b/resources/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-may-24"
+    docker-tag         = "gemini-3h-2024-jun-11"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-may-24"
+    docker-tag         = "gemini-3h-2024-jun-11"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-may-24"
+    docker-tag         = "gemini-3h-2024-jun-11"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-may-24"
+    docker-tag         = "gemini-3h-2024-jun-11"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-may-24"
+    docker-tag         = "gemini-3h-2024-jun-11"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-may-24"
+    docker-tag             = "gemini-3h-2024-jun-11"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"

--- a/resources/gemini-3h/main.tf
+++ b/resources/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-18"
+    docker-tag         = "gemini-3h-2024-jul-05"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-18"
+    docker-tag         = "gemini-3h-2024-jul-05"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["full"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-18"
+    docker-tag         = "gemini-3h-2024-jul-05"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -56,7 +56,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-18"
+    docker-tag         = "gemini-3h-2024-jul-05"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -71,7 +71,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-jun-18"
+    docker-tag         = "gemini-3h-2024-jul-05"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -89,7 +89,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "subspace"
-    docker-tag             = "gemini-3h-2024-jun-18"
+    docker-tag             = "gemini-3h-2024-jul-05"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `docker-tag` values in the `resources/gemini-3h/main.tf` file for various instances to reflect the new version `gemini-3h-2024-jul-05`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update docker-tag values for gemini-3h instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/gemini-3h/main.tf

<li>Updated <code>docker-tag</code> values for multiple instances from <br><code>gemini-3h-2024-may-24</code> to <code>gemini-3h-2024-jul-05</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/infra/pull/320/files#diff-83d1daccff89c413536b6dd17f663d4f58f0e3f1d5f8347356bc312ed0dd4b27">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

