### PR TITLE
increase default parameters

### DIFF
--- a/templates/scripts/create_bootstrap_node_compose_file.sh
+++ b/templates/scripts/create_bootstrap_node_compose_file.sh
@@ -144,12 +144,12 @@ cat >> ~/subspace/docker-compose.yml << EOF
       "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/udp/30433/quic-v1",
       "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/tcp/30433",
       "--node-key", "\${NODE_KEY}",
-      "--in-peers", "1000",
-      "--out-peers", "1000",
-      "--dsn-in-connections", "1000",
-      "--dsn-out-connections", "1000",
-      "--dsn-pending-in-connections", "1000",
-      "--dsn-pending-out-connections", "1000",
+      "--in-peers", "2000",
+      "--out-peers", "2000",
+      "--dsn-in-connections", "2000",
+      "--dsn-out-connections", "2000",
+      "--dsn-pending-in-connections", "2000",
+      "--dsn-pending-out-connections", "2000",
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 

--- a/templates/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/templates/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -145,12 +145,12 @@ cat >> ~/subspace/docker-compose.yml << EOF
 #      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/udp/30433/quic-v1",
 #      "--dsn-external-address", "/ip6/$EXTERNAL_IP_V6/tcp/30433",
       "--node-key", "\${NODE_KEY}",
-      "--in-peers", "1000",
-      "--out-peers", "1000",
-      "--dsn-in-connections", "1000",
-      "--dsn-out-connections", "1000",
-      "--dsn-pending-in-connections", "1000",
-      "--dsn-pending-out-connections", "1000",
+      "--in-peers", "2000",
+      "--out-peers", "2000",
+      "--dsn-in-connections", "2000",
+      "--dsn-out-connections", "2000",
+      "--dsn-pending-in-connections", "2000",
+      "--dsn-pending-out-connections", "2000",
       "--prometheus-listen-on", "0.0.0.0:9615",
 EOF
 

--- a/templates/scripts/create_domain_node_compose_file.sh
+++ b/templates/scripts/create_domain_node_compose_file.sh
@@ -47,7 +47,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.10
+    image: traefik:v2.11.6
     container_name: traefik
     restart: unless-stopped
     command:
@@ -115,7 +115,7 @@ services:
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "500",
       "--out-peers", "250",
-      "--rpc-max-connections", "10000",
+      "--rpc-max-connections", "15000",
       "--rpc-cors", "all",
       "--rpc-listen-on", "0.0.0.0:9944",
       "--rpc-methods", "safe",

--- a/templates/scripts/create_rpc_node_compose_file.sh
+++ b/templates/scripts/create_rpc_node_compose_file.sh
@@ -47,7 +47,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.10
+    image: traefik:v2.11.6
     container_name: traefik
     restart: unless-stopped
     command:
@@ -112,7 +112,7 @@ services:
       "--node-key", "\${NODE_KEY}",
       "--in-peers", "500",
       "--out-peers", "250",
-      "--rpc-max-connections", "10000",
+      "--rpc-max-connections", "15000",
       "--rpc-cors", "all",
       "--rpc-listen-on", "0.0.0.0:9944",
       "--rpc-methods", "safe",


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Increased the default values for `--in-peers`, `--out-peers`, `--dsn-in-connections`, `--dsn-out-connections`, `--dsn-pending-in-connections`, and `--dsn-pending-out-connections` from 1000 to 2000 in `create_bootstrap_node_compose_file.sh` and `create_bootstrap_node_evm_compose_file.sh`.
- Updated `traefik` image version from `v2.10` to `v2.11.6` in `create_domain_node_compose_file.sh` and `create_rpc_node_compose_file.sh`.
- Increased the default value for `--rpc-max-connections` from 10000 to 15000 in `create_domain_node_compose_file.sh` and `create_rpc_node_compose_file.sh`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_compose_file.sh</strong><dd><code>Increase peer and connection limits in bootstrap node compose script</code></dd></summary>
<hr>

templates/scripts/create_bootstrap_node_compose_file.sh

<li>Increased the default values for <code>--in-peers</code>, <code>--out-peers</code>, <br><code>--dsn-in-connections</code>, <code>--dsn-out-connections</code>, <br><code>--dsn-pending-in-connections</code>, and <code>--dsn-pending-out-connections</code> from <br>1000 to 2000.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/infra/pull/324/files#diff-2271654a610f81334999de0798a524684403b62e6b586ae25fafc9af65ff5e55">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_evm_compose_file.sh</strong><dd><code>Increase peer and connection limits in bootstrap node EVM compose </code><br><code>script</code></dd></summary>
<hr>

templates/scripts/create_bootstrap_node_evm_compose_file.sh

<li>Increased the default values for <code>--in-peers</code>, <code>--out-peers</code>, <br><code>--dsn-in-connections</code>, <code>--dsn-out-connections</code>, <br><code>--dsn-pending-in-connections</code>, and <code>--dsn-pending-out-connections</code> from <br>1000 to 2000.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/infra/pull/324/files#diff-579c50457274d21a7b133283ca6ad7754890686962990edfeb597b93b725b762">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_domain_node_compose_file.sh</strong><dd><code>Update traefik version and increase RPC max connections in domain node </code><br><code>compose script</code></dd></summary>
<hr>

templates/scripts/create_domain_node_compose_file.sh

<li>Updated <code>traefik</code> image version from <code>v2.10</code> to <code>v2.11.6</code>.<br> <li> Increased the default value for <code>--rpc-max-connections</code> from 10000 to <br>15000.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/infra/pull/324/files#diff-57a235dd3c69f6e6cffe833934963a7f6d5e2e5115dcd1ee0afffe95f3f6ec6a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_rpc_node_compose_file.sh</strong><dd><code>Update traefik version and increase RPC max connections in RPC node </code><br><code>compose script</code></dd></summary>
<hr>

templates/scripts/create_rpc_node_compose_file.sh

<li>Updated <code>traefik</code> image version from <code>v2.10</code> to <code>v2.11.6</code>.<br> <li> Increased the default value for <code>--rpc-max-connections</code> from 10000 to <br>15000.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/infra/pull/324/files#diff-323b685c25592e8291aa625eff5ec39fa305e5ccd8c69e2cf47ad1e416ba3216">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

