### PR TITLE
bump gemini-3h release

### DIFF
--- a/resources/gemini-3h/main.tf
+++ b/resources/gemini-3h/main.tf
@@ -9,7 +9,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-29"
+    docker-tag         = "gemini-3h-2024-sep-03"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -25,7 +25,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-29"
+    docker-tag         = "gemini-3h-2024-sep-03"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -42,7 +42,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["autoid_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-29"
+    docker-tag         = "gemini-3h-2024-sep-03"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -92,7 +92,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-29"
+    docker-tag         = "gemini-3h-2024-sep-03"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -107,7 +107,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-29"
+    docker-tag         = "gemini-3h-2024-sep-03"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -143,7 +143,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "autonomys"
-    docker-tag             = "gemini-3h-2024-jul-29"
+    docker-tag             = "gemini-3h-2024-sep-03"
     reserved-only          = false
     prune                  = false
     plot-size              = "100G"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `docker-tag` for various node configurations in the `gemini-3h` module to a new version "gemini-3h-2024-sep-03".
- This change ensures that all relevant node configurations are using the latest Docker image version.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update Docker tag for Gemini-3h configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/gemini-3h/main.tf

<li>Updated the <code>docker-tag</code> for multiple configurations from <br>"gemini-3h-2024-jul-29" to "gemini-3h-2024-sep-03".<br> <li> Changes affect configurations for bootstrap, evm bootstrap, autoid <br>bootstrap, rpc, domain, and farmer nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/336/files#diff-83d1daccff89c413536b6dd17f663d4f58f0e3f1d5f8347356bc312ed0dd4b27">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

