### PR TITLE
fixes to hasura service on monolith squid

### DIFF
--- a/templates/terraform/explorer/base/scripts/create_nova_squid_node_compose_file.sh
+++ b/templates/terraform/explorer/base/scripts/create_nova_squid_node_compose_file.sh
@@ -86,11 +86,11 @@ services:
   graphql-engine:
     image: hasura/graphql-engine:v2.40.0
     depends_on:
-      - "postgres"
+      - "db"
     restart: always
     environment:
       ## postgres database to store Hasura metadata
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@db:5432/postgres
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@db:5432/\${POSTGRES_DB}
       ## enable the console served by server
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set "false" to disable console
       ## enable debugging mode. It is recommended to disable this in production

--- a/templates/terraform/explorer/base/scripts/create_squid_node_compose_file.sh
+++ b/templates/terraform/explorer/base/scripts/create_squid_node_compose_file.sh
@@ -86,11 +86,11 @@ services:
   graphql-engine:
     image: hasura/graphql-engine:v2.40.0
     depends_on:
-      - "postgres"
+      - "db"
     restart: always
     environment:
       ## postgres database to store Hasura metadata
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@db:5432/postgres
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://\${POSTGRES_USER}:\${POSTGRES_PASSWORD}@db:5432/\${POSTGRES_DB}
       ## enable the console served by server
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set "false" to disable console
       ## enable debugging mode. It is recommended to disable this in production


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the dependency in the Hasura service configuration from `postgres` to `db` in both `create_nova_squid_node_compose_file.sh` and `create_squid_node_compose_file.sh`.
- Updated the `HASURA_GRAPHQL_METADATA_DATABASE_URL` to dynamically use the `POSTGRES_DB` environment variable instead of hardcoding the database name.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_nova_squid_node_compose_file.sh</strong><dd><code>Fix Hasura service configuration in nova squid node script</code></dd></summary>
<hr>

templates/terraform/explorer/base/scripts/create_nova_squid_node_compose_file.sh

<li>Changed dependency from <code>postgres</code> to <code>db</code>.<br> <li> Updated <code>HASURA_GRAPHQL_METADATA_DATABASE_URL</code> to use <code>POSTGRES_DB</code> <br>environment variable.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/337/files#diff-4da78a9e294b12c816d519f734a11a4074bcaf8412c994a89695a34a6ca1fc08">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_squid_node_compose_file.sh</strong><dd><code>Fix Hasura service configuration in squid node script</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/explorer/base/scripts/create_squid_node_compose_file.sh

<li>Changed dependency from <code>postgres</code> to <code>db</code>.<br> <li> Updated <code>HASURA_GRAPHQL_METADATA_DATABASE_URL</code> to use <code>POSTGRES_DB</code> <br>environment variable.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/337/files#diff-b2b8aba27d8d7281080fb3886c93c69c47e38b42e859851d513b507b159d6e0e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

