### PR TITLE
set farming-thread-pool-size for farmer

### DIFF
--- a/ansible/network/files/docker-compose-farmer.yml
+++ b/ansible/network/files/docker-compose-farmer.yml
@@ -70,8 +70,7 @@ services:
       "--reward-address", "${REWARD_ADDRESS}",
       "--metrics-endpoint=0.0.0.0:9616",
       "--cache-percentage", "50",
-      "--farm-during-initial-plotting", "true",
-      "--plotting-thread-pool-size", "4",
+      "--farming-thread-pool-size", "4",
     ]
 
   archival-node:

--- a/templates/scripts/create_farmer_node_compose_file.sh
+++ b/templates/scripts/create_farmer_node_compose_file.sh
@@ -73,6 +73,7 @@ services:
       "--reward-address", "\${REWARD_ADDRESS}",
       "--metrics-endpoint=0.0.0.0:9616",
       "--cache-percentage", "50",
+      "--farming-thread-pool-size", "4",
     ]
 
   archival-node:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new parameter `--farming-thread-pool-size` with a value of "4" to the farmer node configuration in both the shell script and the Docker Compose file.
- Removed obsolete parameters `--farm-during-initial-plotting` and `--plotting-thread-pool-size` from the Docker Compose file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_farmer_node_compose_file.sh</strong><dd><code>Add farming thread pool size parameter to farmer node</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_farmer_node_compose_file.sh

- Added `--farming-thread-pool-size` parameter with a value of "4".



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/338/files#diff-5dcf56bcd2b28fe1f091ee88404cf9176cf0c024058bc3b3655d871cc6864361">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-farmer.yml</strong><dd><code>Update farmer node configuration with new thread pool size</code></dd></summary>
<hr>

ansible/network/files/docker-compose-farmer.yml

<li>Added <code>--farming-thread-pool-size</code> parameter with a value of "4".<br> <li> Removed <code>--farm-during-initial-plotting</code> and <code>--plotting-thread-pool-size</code> <br>parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/338/files#diff-b0a08fd088ce2ccf32947cb8995102e4f280e9192157e755ccfdd934e915cfe9">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

