### PR TITLE
update script to launch timekeeper first

### DIFF
--- a/scripts/launch-nodes/manage_subspace.py
+++ b/scripts/launch-nodes/manage_subspace.py
@@ -233,14 +233,15 @@ def main():
             # Run sudo docker compose down -v for the bootstrap node
             docker_compose_down(client, subspace_dir)
 
-            # Modify .env with the new GENESIS_HASH
-            modify_env_file(client, subspace_dir, release_version, genesis_hash=protocol_version_hash)
+            # Modify .env with the new GENESIS_HASH and POT_EXTERNAL_ENTROPY
+            modify_env_file(client, subspace_dir, release_version, genesis_hash=protocol_version_hash, pot_external_entropy=args.pot_external_entropy)
 
             # Start the bootstrap node
             docker_compose_up(client, subspace_dir)
 
             client.close()
-            logger.info("Bootstrap node started with the updated Genesis Hash.")
+            logger.info("Bootstrap node started with the updated Genesis Hash and POT_EXTERNAL_ENTROPY.")
+
         except Exception as e:
             logger.error(f"Error during bootstrap node update: {e}")
         finally:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the script to prioritize handling the timekeeper node before other nodes.
- Modified the `.env` file for the timekeeper node with the `POT_EXTERNAL_ENTROPY` value.
- Improved logging to provide more detailed information about the timekeeper node operations.
- Simplified and clarified the process for updating and starting farmer and RPC nodes.
- add optional argument to disable updating the timekeeper in case of manual launching


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manage_subspace.py</strong><dd><code>Prioritize timekeeper node in launch script and update <code>.env</code> handling</code></dd></summary>
<hr>

scripts/launch-nodes/manage_subspace.py

<li>Updated the script to handle the timekeeper node first.<br> <li> Modified <code>.env</code> file for the timekeeper with <code>POT_EXTERNAL_ENTROPY</code>.<br> <li> Added logging for timekeeper node operations.<br> <li> Simplified the process for handling farmer and RPC nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/346/files#diff-93fec7166f3de7505e122f038dbba08a1a55cbaa2f5abf2ab203541793ea6ecf">+25/-41</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information