### PR TITLE
Gemini 3h upgrade + traefik release bump

### DIFF
--- a/ansible/network/files/docker-compose-autoid.yml
+++ b/ansible/network/files/docker-compose-autoid.yml
@@ -44,7 +44,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.3
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/ansible/network/files/docker-compose-domain.yml
+++ b/ansible/network/files/docker-compose-domain.yml
@@ -44,7 +44,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.3
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/resources/gemini-3h/main.tf
+++ b/resources/gemini-3h/main.tf
@@ -10,7 +10,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-sep-17"
+    docker-tag         = "gemini-3h-2024-oct-10"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -26,7 +26,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-sep-17"
+    docker-tag         = "gemini-3h-2024-oct-10"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -43,7 +43,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["autoid_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-sep-17"
+    docker-tag         = "gemini-3h-2024-oct-10"
     reserved-only      = false
     prune              = false
     genesis-hash       = "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34"
@@ -60,7 +60,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc-squid"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-16"
+    docker-tag         = "gemini-3h-2024-oct-10"
     domain-prefix      = "rpc-squid"
     reserved-only      = false
     prune              = false
@@ -75,7 +75,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["nova-squid"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-jul-16"
+    docker-tag         = "gemini-3h-2024-oct-10"
     domain-prefix      = "nova-squid"
     reserved-only      = false
     prune              = false
@@ -93,7 +93,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-sep-17"
+    docker-tag         = "gemini-3h-2024-oct-10"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -108,7 +108,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "autonomys"
-    docker-tag         = "gemini-3h-2024-sep-17"
+    docker-tag         = "gemini-3h-2024-oct-10"
     domain-prefix      = "nova"
     reserved-only      = false
     prune              = false
@@ -126,7 +126,7 @@ module "gemini-3h" {
     regions            = var.aws_region
     instance-count     = var.instance_count["autoid"]
     docker-org         = "subspace"
-    docker-tag         = "gemini-3h-2024-may-06"
+    docker-tag         = "gemini-3h-2024-oct-10"
     domain-prefix      = ["autoid"]
     reserved-only      = false
     prune              = false
@@ -144,7 +144,7 @@ module "gemini-3h" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "autonomys"
-    docker-tag             = "gemini-3h-2024-sep-17"
+    docker-tag             = "gemini-3h-2024-oct-10"
     reserved-only          = false
     prune                  = false
     plot-size              = "10G"

--- a/templates/scripts/create_domain_node_compose_file.sh
+++ b/templates/scripts/create_domain_node_compose_file.sh
@@ -47,7 +47,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.6
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/templates/scripts/create_rpc_node_compose_file.sh
+++ b/templates/scripts/create_rpc_node_compose_file.sh
@@ -47,7 +47,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.6
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_domain_node_compose_file.sh
+++ b/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_domain_node_compose_file.sh
@@ -47,7 +47,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.6
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_rpc_node_compose_file.sh
+++ b/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_rpc_node_compose_file.sh
@@ -47,7 +47,7 @@ services:
 
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.6
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/testing-framework/ec2/base/scripts/create_autoid_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_autoid_node_compose_file.sh
@@ -15,7 +15,7 @@ networks:
 services:
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.3
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh
@@ -15,7 +15,7 @@ networks:
 services:
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.3
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:

--- a/testing-framework/ec2/base/scripts/create_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_node_compose_file.sh
@@ -15,7 +15,7 @@ networks:
 services:
   # traefik reverse proxy with automatic tls management using let encrypt
   traefik:
-    image: traefik:v2.11.3
+    image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
     command:


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the `docker-tag` for various Gemini 3h node configurations to "gemini-3h-2024-oct-10" in the Terraform configuration file.
- Bumped the Traefik image version from v2.11.x to v3.1.6 across multiple shell scripts and YAML files for domain, RPC, and autoid nodes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update Docker tags for Gemini 3h nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/gemini-3h/main.tf

<li>Updated <code>docker-tag</code> for multiple node configurations to <br>"gemini-3h-2024-oct-10".<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-83d1daccff89c413536b6dd17f663d4f58f0e3f1d5f8347356bc312ed0dd4b27">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>create_domain_node_compose_file.sh</strong><dd><code>Bump Traefik version in domain node script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_domain_node_compose_file.sh

- Updated Traefik image version from v2.11.6 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-57a235dd3c69f6e6cffe833934963a7f6d5e2e5115dcd1ee0afffe95f3f6ec6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_rpc_node_compose_file.sh</strong><dd><code>Bump Traefik version in RPC node script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_rpc_node_compose_file.sh

- Updated Traefik image version from v2.11.6 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-323b685c25592e8291aa625eff5ec39fa305e5ccd8c69e2cf47ad1e416ba3216">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_domain_node_compose_file.sh</strong><dd><code>Update Traefik version in archived domain node script</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/network-primitives-archive/gemini-3h/scripts/create_domain_node_compose_file.sh

- Updated Traefik image version from v2.11.6 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-cebdec73f2ad7464d9b5360aba0e5125258f21ffc847446104b45e1f086fd46d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_rpc_node_compose_file.sh</strong><dd><code>Update Traefik version in archived RPC node script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/network-primitives-archive/gemini-3h/scripts/create_rpc_node_compose_file.sh

- Updated Traefik image version from v2.11.6 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-9d2df017eae37ba724fb3780cc10e94074e955ca3db989f67de0a79f72c30399">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_autoid_node_compose_file.sh</strong><dd><code>Bump Traefik version in autoid node script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_autoid_node_compose_file.sh

- Updated Traefik image version from v2.11.3 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-5224422bfdad979b7c49e93e6eb777ab648f2f9ddad4b6ce82d36fd1a88653b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_domain_node_compose_file.sh</strong><dd><code>Bump Traefik version in domain node script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_domain_node_compose_file.sh

- Updated Traefik image version from v2.11.3 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-92605d9e2db2b8ef367e7706b6b25917ebeffeac268c11c569fe63183fb318ba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_node_compose_file.sh</strong><dd><code>Bump Traefik version in node script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_node_compose_file.sh

- Updated Traefik image version from v2.11.3 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-446f4ff8b7842028d02cc4d0abfc120285943835e015e381a0b2a0cb2cc1a6b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-autoid.yml</strong><dd><code>Update Traefik version in autoid docker-compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/network/files/docker-compose-autoid.yml

- Updated Traefik image version from v2.11.3 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-2dfa6d3836759c26aa95ce4810ebad7c084815d43a701a426a5d8bc485f591fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-domain.yml</strong><dd><code>Update Traefik version in domain docker-compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/network/files/docker-compose-domain.yml

- Updated Traefik image version from v2.11.3 to v3.1.6.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/355/files#diff-186921172e472602ae26c578a019543f9775b6522ad5443c9c5815854112216b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information