### PR TITLE
mount farmer identity

### DIFF
--- a/templates/terraform/network-primitives/farmer_node_provisioner.tf
+++ b/templates/terraform/network-primitives/farmer_node_provisioner.tf
@@ -108,7 +108,6 @@ resource "null_resource" "start-farmer-nodes" {
     timeout     = "300s"
   }
 
-  # copy farmer identity files (todo: reset this after)
   provisioner "file" {
     source      = "./identity.bin"
     destination = "/home/${var.ssh_user}/subspace/identity.bin"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed an outdated comment in the Terraform configuration regarding farmer identity files.
- Enhanced the Docker Compose script by adding a read-only volume mount for `identity.bin`, ensuring the farmer identity is properly mounted.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>farmer_node_provisioner.tf</strong><dd><code>Remove outdated comment regarding farmer identity files</code>&nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/network-primitives/farmer_node_provisioner.tf

- Removed a comment about resetting farmer identity files.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/365/files#diff-864a15c7a7f4589c460183c1aa24e68bf973e827beaaee67c898192e06325b87">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_farmer_node_compose_file.sh</strong><dd><code>Add volume mount for farmer identity in Docker Compose</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_farmer_node_compose_file.sh

<li>Added a volume mount for <code>identity.bin</code> in the Docker Compose <br>configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/365/files#diff-5dcf56bcd2b28fe1f091ee88404cf9176cf0c024058bc3b3655d871cc6864361">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information