### PR TITLE
change metrics flag

### DIFF
--- a/ansible/network/files/docker-compose-bootstrap-autoid.yml
+++ b/ansible/network/files/docker-compose-bootstrap-autoid.yml
@@ -53,7 +53,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - ${DSN_NODE_KEY}
       - "--listen-on"

--- a/ansible/network/files/docker-compose-bootstrap-domain.yml
+++ b/ansible/network/files/docker-compose-bootstrap-domain.yml
@@ -53,7 +53,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - ${DSN_NODE_KEY}
       - "--listen-on"

--- a/ansible/network/files/docker-compose-bootstrap.yml
+++ b/ansible/network/files/docker-compose-bootstrap.yml
@@ -53,7 +53,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - ${DSN_NODE_KEY}
       - "--listen-on"

--- a/ansible/network/files/docker-compose-farmer.yml
+++ b/ansible/network/files/docker-compose-farmer.yml
@@ -63,7 +63,7 @@ services:
       "--listen-on", "/ip4/0.0.0.0/tcp/30533",
       "--listen-on", "/ip6/::/tcp/30533",
       "--reward-address", "${REWARD_ADDRESS}",
-      "--metrics-endpoint=0.0.0.0:9616",
+      "--prometheus-listen-on=0.0.0.0:9616",
       "--cache-percentage", "${CACHE_PERCENTAGE}",
       "--farming-thread-pool-size", "${THREAD_POOL_SIZE}",
     ]

--- a/kubernetes/devnet/base/bootstrap-domain-node/archival-node.yaml
+++ b/kubernetes/devnet/base/bootstrap-domain-node/archival-node.yaml
@@ -123,7 +123,7 @@ spec:
           periodSeconds: 30
         args:
           - "start"
-          - "--metrics-endpoints=0.0.0.0:9616"
+          - "--prometheus-listen-on=0.0.0.0:9616"
           - "--keypair"
           - ${DSN_NODE_KEY}
           - "--listen-on"

--- a/kubernetes/devnet/base/bootstrap-node/archival-node.yaml
+++ b/kubernetes/devnet/base/bootstrap-node/archival-node.yaml
@@ -120,7 +120,7 @@ spec:
           periodSeconds: 30
         args:
           - "start"
-          - "--metrics-endpoints=0.0.0.0:9616"
+          - "--prometheus-listen-on=0.0.0.0:9616"
           - "--keypair"
           - ${DSN_NODE_KEY}
           - "--listen-on"

--- a/kubernetes/devnet/base/farmer/archival-node.yaml
+++ b/kubernetes/devnet/base/farmer/archival-node.yaml
@@ -159,7 +159,7 @@ spec:
           - "/ip6/::/tcp/30533"
           - "--reward-address"
           - "$(REWARD_ADDRESS)"
-          - "--metrics-endpoint=0.0.0.0:9616"
+          - "--prometheus-listen-on=0.0.0.0:9616"
           - "--cache-percentage"
           - "50"
       volumes:

--- a/templates/scripts/create_bootstrap_node_compose_file.sh
+++ b/templates/scripts/create_bootstrap_node_compose_file.sh
@@ -60,7 +60,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/templates/scripts/create_bootstrap_node_domain_compose_file.sh
+++ b/templates/scripts/create_bootstrap_node_domain_compose_file.sh
@@ -62,7 +62,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/templates/scripts/create_farmer_node_compose_file.sh
+++ b/templates/scripts/create_farmer_node_compose_file.sh
@@ -66,7 +66,7 @@ services:
       "--listen-on", "/ip4/0.0.0.0/tcp/30533",
       "--listen-on", "/ip6/::/tcp/30533",
       "--reward-address", "\${REWARD_ADDRESS}",
-      "--metrics-endpoint=0.0.0.0:9616",
+      "--prometheus-listen-on=0.0.0.0:9616",
       "--cache-percentage", "\${CACHE_PERCENTAGE}",
       "--farming-thread-pool-size", "\${THREAD_POOL_SIZE}",
     ]

--- a/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_bootstrap_node_compose_file.sh
+++ b/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_bootstrap_node_compose_file.sh
@@ -60,7 +60,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_bootstrap_node_domain_compose_file.sh
+++ b/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_bootstrap_node_domain_compose_file.sh
@@ -62,7 +62,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_farmer_node_compose_file.sh
+++ b/templates/terraform/network-primitives-archive/gemini-3h/scripts/create_farmer_node_compose_file.sh
@@ -66,7 +66,7 @@ services:
       "--listen-on", "/ip4/0.0.0.0/tcp/30533",
       "--listen-on", "/ip6/::/tcp/30533",
       "--reward-address", "\${REWARD_ADDRESS}",
-      "--metrics-endpoint=0.0.0.0:9616",
+      "--prometheus-listen-on=0.0.0.0:9616",
       "--cache-percentage", "\${CACHE_PERCENTAGE}",
       "--farming-thread-pool-size", "\${THREAD_POOL_SIZE}",
     ]

--- a/testing-framework/ec2/base/scripts/create_bootstrap_node_autoid_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_bootstrap_node_autoid_compose_file.sh
@@ -33,7 +33,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh
@@ -31,7 +31,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/testing-framework/ec2/base/scripts/create_bootstrap_node_evm_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_bootstrap_node_evm_compose_file.sh
@@ -34,7 +34,7 @@ services:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
     command:
       - start
-      - "--metrics-endpoints=0.0.0.0:9616"
+      - "--prometheus-listen-on=0.0.0.0:9616"
       - "--keypair"
       - \${DSN_NODE_KEY}
       - "--listen-on"

--- a/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
+++ b/testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh
@@ -37,7 +37,7 @@ services:
       "--listen-on", "/ip4/0.0.0.0/tcp/30533",
       "--listen-on", "/ip6/::/tcp/30533",
       "--reward-address", "\${REWARD_ADDRESS}",
-      "--metrics-endpoint=0.0.0.0:9616",
+      "--prometheus-listen-on=0.0.0.0:9616",
       "--cache-percentage", "\${CACHE_PERCENTAGE}",
       "--farming-thread-pool-size", "\${THREAD_POOL_SIZE}",
     ]


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the metrics flag across multiple scripts and configuration files from `--metrics-endpoints` or `--metrics-endpoint` to `--prometheus-listen-on`.
- Changes affect shell scripts, YAML configuration files for Docker Compose, and Kubernetes configurations.
- This change standardizes the metrics flag usage across different environments and setups.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_compose_file.sh</strong><dd><code>Update metrics flag in bootstrap node compose script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_bootstrap_node_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-2271654a610f81334999de0798a524684403b62e6b586ae25fafc9af65ff5e55">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_domain_compose_file.sh</strong><dd><code>Update metrics flag in bootstrap node domain compose script</code></dd></summary>
<hr>

templates/scripts/create_bootstrap_node_domain_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-b089e3b5827e57908d2062047797e5c428a3951d3f7ee672f8dcbb345d247c9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_farmer_node_compose_file.sh</strong><dd><code>Update metrics flag in farmer node compose script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_farmer_node_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoint</code> to <br><code>--prometheus-listen-on</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-5dcf56bcd2b28fe1f091ee88404cf9176cf0c024058bc3b3655d871cc6864361">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_compose_file.sh</strong><dd><code>Update metrics flag in archived bootstrap node compose script</code></dd></summary>
<hr>

templates/terraform/network-primitives-archive/gemini-3h/scripts/create_bootstrap_node_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-0ed0c105041519e9d3c817ea00d516e3ef9c0688d880996cd59910688613aad2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_domain_compose_file.sh</strong><dd><code>Update metrics flag in archived bootstrap node domain compose script</code></dd></summary>
<hr>

templates/terraform/network-primitives-archive/gemini-3h/scripts/create_bootstrap_node_domain_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-743538c7858c41366ad4265372046e977da459d36132ee4b728cf666416144de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_farmer_node_compose_file.sh</strong><dd><code>Update metrics flag in archived farmer node compose script</code></dd></summary>
<hr>

templates/terraform/network-primitives-archive/gemini-3h/scripts/create_farmer_node_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoint</code> to <br><code>--prometheus-listen-on</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-62c4f73eb8d0a874e9925e406fc49e6ee4d59a9ccb4702d43368360295a80819">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_autoid_compose_file.sh</strong><dd><code>Update metrics flag in EC2 autoid bootstrap node compose script</code></dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_bootstrap_node_autoid_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-4ed0c9c07eeee62dbcfc5aa4ac21ced86a39b8c3cfe59f77e64bc3c43d67545e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_compose_file.sh</strong><dd><code>Update metrics flag in EC2 bootstrap node compose script</code>&nbsp; </dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_bootstrap_node_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-ab5fed8ed143b3332c9b820b02a588209faa7e153c0424ea0821914b00c27ce5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_bootstrap_node_evm_compose_file.sh</strong><dd><code>Update metrics flag in EC2 EVM bootstrap node compose script</code></dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_bootstrap_node_evm_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-127a9888258ae3034bdb42c827629a10211f4264073bd4addb5f801fec1a24e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_farmer_node_compose_file.sh</strong><dd><code>Update metrics flag in EC2 farmer node compose script</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

testing-framework/ec2/base/scripts/create_farmer_node_compose_file.sh

<li>Changed metrics flag from <code>--metrics-endpoint</code> to <br><code>--prometheus-listen-on</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-b706ab45f4d1829199f3bfac3ca73ad8a1d0f6b7d7c1f957805b9025a95e27d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-bootstrap-autoid.yml</strong><dd><code>Update metrics flag in Ansible autoid bootstrap compose file</code></dd></summary>
<hr>

ansible/network/files/docker-compose-bootstrap-autoid.yml

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-5dabb314846e371e34a993039d372a8ce95ab1338c090676ff113ed15b7eb8a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-bootstrap-domain.yml</strong><dd><code>Update metrics flag in Ansible domain bootstrap compose file</code></dd></summary>
<hr>

ansible/network/files/docker-compose-bootstrap-domain.yml

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-665e6416494eeaad41822df0d2d07e9d1d2a386b6b8653e71d7a32b7b2fcc7b8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-bootstrap.yml</strong><dd><code>Update metrics flag in Ansible bootstrap compose file</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/network/files/docker-compose-bootstrap.yml

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-6a585606cde445d794ca7bfbbce5ef8422ad48fd9015974b8d096aa95a968f5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-farmer.yml</strong><dd><code>Update metrics flag in Ansible farmer compose file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/network/files/docker-compose-farmer.yml

<li>Changed metrics flag from <code>--metrics-endpoint</code> to <br><code>--prometheus-listen-on</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-b0a08fd088ce2ccf32947cb8995102e4f280e9192157e755ccfdd934e915cfe9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>archival-node.yaml</strong><dd><code>Update metrics flag in Kubernetes domain node archival config</code></dd></summary>
<hr>

kubernetes/devnet/base/bootstrap-domain-node/archival-node.yaml

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-8f406fa9a22d59707564e2982062351968fd974319d584bd46ffa76d112975a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>archival-node.yaml</strong><dd><code>Update metrics flag in Kubernetes bootstrap node archival config</code></dd></summary>
<hr>

kubernetes/devnet/base/bootstrap-node/archival-node.yaml

<li>Changed metrics flag from <code>--metrics-endpoints</code> to <br><code>--prometheus-listen-ons</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-c02d9076e2547f3018d5effc3be2335f7f7f95eab53e899411aba9841809b287">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>archival-node.yaml</strong><dd><code>Update metrics flag in Kubernetes farmer archival config</code>&nbsp; </dd></summary>
<hr>

kubernetes/devnet/base/farmer/archival-node.yaml

<li>Changed metrics flag from <code>--metrics-endpoint</code> to <br><code>--prometheus-listen-on</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/379/files#diff-8c1afee90a6aa3bf92e3b493798326f18dc85aa438cbe649d25951fdcd2733e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information