### PR TITLE
add more rpc endpoints

### DIFF
--- a/templates/scripts/create_domain_node_compose_file.sh
+++ b/templates/scripts/create_domain_node_compose_file.sh
@@ -87,7 +87,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.archival-node.loadbalancer.server.port=8944"
-      - "traefik.http.routers.archival-node.rule=Host(\`\${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network\`) && Path(\`/ws\`)"
+      - "traefik.http.routers.archival-node.rule=Host(\`\${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network || \${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network || \${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.autonomys.xyz\`) && Path(\`/ws\`)"
       - "traefik.http.routers.archival-node.tls=true"
       - "traefik.http.routers.archival-node.tls.certresolver=le"
       - "traefik.http.routers.archival-node.entrypoints=websecure"

--- a/templates/scripts/create_rpc_node_compose_file.sh
+++ b/templates/scripts/create_rpc_node_compose_file.sh
@@ -80,7 +80,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.archival-node.loadbalancer.server.port=9944"
-      - "traefik.http.routers.archival-node.rule=Host(\`\${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network\`) && Path(\`/ws\`)"
+      - "traefik.http.routers.archival-node.rule=Host(\`\${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network || \${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.subspace.network || \${DOMAIN_PREFIX}-\${NODE_ID}.\${NETWORK_NAME}.autonomys.xyz\`) && Path(\`/ws\`)"
       - "traefik.http.routers.archival-node.tls=true"
       - "traefik.http.routers.archival-node.tls.certresolver=le"
       - "traefik.http.routers.archival-node.entrypoints=websecure"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the domain routing rules in the `create_domain_node_compose_file.sh` and `create_rpc_node_compose_file.sh` scripts.
- Added `autonomys.xyz` as a valid domain option in the `traefik.http.routers.archival-node.rule`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_domain_node_compose_file.sh</strong><dd><code>Enhance domain routing rules in compose file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_domain_node_compose_file.sh

<li>Updated the <code>traefik.http.routers.archival-node.rule</code> to include <br>additional domain options.<br> <li> Added <code>autonomys.xyz</code> as a valid domain in the rule.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/383/files#diff-57a235dd3c69f6e6cffe833934963a7f6d5e2e5115dcd1ee0afffe95f3f6ec6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_rpc_node_compose_file.sh</strong><dd><code>Enhance domain routing rules in RPC compose file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/scripts/create_rpc_node_compose_file.sh

<li>Updated the <code>traefik.http.routers.archival-node.rule</code> to include <br>additional domain options.<br> <li> Added <code>autonomys.xyz</code> as a valid domain in the rule.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/383/files#diff-323b685c25592e8291aa625eff5ec39fa305e5ccd8c69e2cf47ad1e416ba3216">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information