### PR TITLE
bump mainnet release mainnet-2024-nov-28

### DIFF
--- a/resources/mainnet/main.tf
+++ b/resources/mainnet/main.tf
@@ -10,7 +10,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     reserved-only      = false
     prune              = false
     genesis-hash       = "b256e3ca1d3ef43c1e52799df670aa307671b9e468c500def1f5b6b77173b5d4"
@@ -26,7 +26,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     reserved-only      = false
     prune              = false
     genesis-hash       = "b256e3ca1d3ef43c1e52799df670aa307671b9e468c500def1f5b6b77173b5d4"
@@ -43,7 +43,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["autoid_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     reserved-only      = false
     prune              = false
     genesis-hash       = "b256e3ca1d3ef43c1e52799df670aa307671b9e468c500def1f5b6b77173b5d4"
@@ -60,7 +60,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc-indexer"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     domain-prefix      = "rpc-indexer"
     reserved-only      = false
     prune              = false
@@ -75,7 +75,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["nova-indexer"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     domain-prefix      = "nova-indexer"
     reserved-only      = false
     prune              = false
@@ -93,7 +93,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -108,7 +108,7 @@ module "mainnet" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "autonomys"
-    docker-tag         = "mainnet-2024-nov-18"
+    docker-tag         = "mainnet-2024-nov-28"
     domain-prefix      = ["nova", "autoid"]
     reserved-only      = false
     prune              = false
@@ -126,7 +126,7 @@ module "mainnet" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "autonomys"
-    docker-tag             = "mainnet-2024-nov-18"
+    docker-tag             = "mainnet-2024-nov-28"
     reserved-only          = false
     prune                  = false
     plot-size              = "10G"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `docker-tag` for various node configurations in the mainnet Terraform configuration file.
- The tag was changed from `mainnet-2024-nov-18` to `mainnet-2024-nov-28` to reflect the new release version.
- This change affects multiple node configurations, including bootstrap, EVM, autoid, RPC, nova indexer, domain, and farmer nodes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update Docker tags for mainnet node configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/mainnet/main.tf

<li>Updated <code>docker-tag</code> for multiple node configurations.<br> <li> Changed tag from <code>mainnet-2024-nov-18</code> to <code>mainnet-2024-nov-28</code>.<br> <li> Affected configurations include bootstrap, EVM, autoid, RPC, nova <br>indexer, domain, and farmer nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/384/files#diff-a57f3d48fbbd3295fb5660a99d5b91cce340a219f167f1c42ff2779d37a8853a">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information