### PR TITLE
update nova label to auto-evm

### DIFF
--- a/resources/mainnet/main.tf
+++ b/resources/mainnet/main.tf
@@ -76,7 +76,7 @@ module "mainnet" {
     instance-count     = var.instance_count["nova-indexer"]
     docker-org         = "autonomys"
     docker-tag         = "mainnet-2024-nov-28"
-    domain-prefix      = "nova-indexer"
+    domain-prefix      = "auto-evm-indexer"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -109,7 +109,7 @@ module "mainnet" {
     instance-count     = var.instance_count["domain"]
     docker-org         = "autonomys"
     docker-tag         = "mainnet-2024-nov-28"
-    domain-prefix      = ["nova", "autoid"]
+    domain-prefix      = ["auto-evm", "autoid"]
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433

--- a/resources/mainnet/variables.tf
+++ b/resources/mainnet/variables.tf
@@ -20,7 +20,7 @@ variable "domain_id" {
 variable "domain_labels" {
   description = "Tag of the domain to run"
   type        = list(string)
-  default     = ["nova", "autoid"]
+  default     = ["auto-evm", "autoid"]
 }
 
 variable "instance_type" {

--- a/resources/taurus/main.tf
+++ b/resources/taurus/main.tf
@@ -76,7 +76,7 @@ module "taurus" {
     instance-count     = var.instance_count["nova-indexer"]
     docker-org         = "autonomys"
     docker-tag         = "taurus-2024-nov-05"
-    domain-prefix      = "nova-indexer"
+    domain-prefix      = "auto-evm-indexer"
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433
@@ -109,7 +109,7 @@ module "taurus" {
     instance-count     = var.instance_count["domain"]
     docker-org         = "autonomys"
     docker-tag         = "taurus-2024-nov-05"
-    domain-prefix      = ["nova", "autoid"]
+    domain-prefix      = ["auto-evm", "autoid"]
     reserved-only      = false
     prune              = false
     node-dsn-port      = 30433

--- a/resources/taurus/variables.tf
+++ b/resources/taurus/variables.tf
@@ -20,7 +20,7 @@ variable "domain_id" {
 variable "domain_labels" {
   description = "Tag of the domain to run"
   type        = list(string)
-  default     = ["nova", "autoid"]
+  default     = ["auto-evm", "autoid"]
 }
 
 variable "instance_type" {

--- a/templates/terraform/network-primitives/bootstrap_node_autoid_provisioner.tf
+++ b/templates/terraform/network-primitives/bootstrap_node_autoid_provisioner.tf
@@ -156,6 +156,7 @@ resource "null_resource" "start-bootstrap-nodes-autoid" {
       "echo NODE_DSN_PORT=${var.bootstrap-node-autoid-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
       "echo OPERATOR_PORT=${var.bootstrap-node-autoid-config.operator-port} >> /home/${var.ssh_user}/subspace/.env",
       "echo GENESIS_HASH=${var.bootstrap-node-autoid-config.genesis-hash} >> /home/${var.ssh_user}/subspace/.env",
+      "echo POT_EXTERNAL_ENTROPY=${var.pot_external_entropy} >> /home/${var.ssh_user}/subspace/.env",
 
       # create docker compose file
       "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-autoid-config.reserved-only} ${length(local.bootstrap_nodes_autoid_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains} ",

--- a/templates/terraform/network-primitives/bootstrap_node_evm_provisioner.tf
+++ b/templates/terraform/network-primitives/bootstrap_node_evm_provisioner.tf
@@ -156,6 +156,7 @@ resource "null_resource" "start-bootstrap-nodes-evm" {
       "echo NODE_DSN_PORT=${var.bootstrap-node-evm-config.node-dsn-port} >> /home/${var.ssh_user}/subspace/.env",
       "echo OPERATOR_PORT=${var.bootstrap-node-evm-config.operator-port} >> /home/${var.ssh_user}/subspace/.env",
       "echo GENESIS_HASH=${var.bootstrap-node-evm-config.genesis-hash} >> /home/${var.ssh_user}/subspace/.env",
+      "echo POT_EXTERNAL_ENTROPY=${var.pot_external_entropy} >> /home/${var.ssh_user}/subspace/.env",
 
       # create docker compose file
       "bash /home/${var.ssh_user}/subspace/create_compose_file.sh ${var.bootstrap-node-evm-config.reserved-only} ${length(local.bootstrap_nodes_evm_ip_v4)} ${count.index} ${length(local.bootstrap_nodes_ip_v4)} ${var.domain-node-config.enable-domains} ",

--- a/templates/terraform/network-primitives/dns.tf
+++ b/templates/terraform/network-primitives/dns.tf
@@ -97,7 +97,7 @@ resource "cloudflare_record" "bootstrap_ipv6" {
 resource "cloudflare_record" "bootstrap_evm" {
   count   = length(local.bootstrap_nodes_evm_ip_v4)
   zone_id = data.cloudflare_zone.cloudflare_zone.id
-  name    = "bootstrap-${count.index}.nova.${var.network_name}"
+  name    = "bootstrap-${count.index}.${var.domain-node-config.domain-prefix[0]}.${var.network_name}"
   value   = local.bootstrap_nodes_evm_ip_v4[count.index]
   type    = "A"
 }
@@ -105,7 +105,7 @@ resource "cloudflare_record" "bootstrap_evm" {
 resource "cloudflare_record" "bootstrap_evm_ipv6" {
   count   = length(local.bootstrap_nodes_evm_ip_v4)
   zone_id = data.cloudflare_zone.cloudflare_zone.id
-  name    = "bootstrap-${count.index}.nova.${var.network_name}"
+  name    = "bootstrap-${count.index}.${var.domain-node-config.domain-prefix[0]}.${var.network_name}"
   value   = local.bootstrap_nodes_evm_ip_v6[count.index]
   type    = "AAAA"
 }
@@ -113,7 +113,7 @@ resource "cloudflare_record" "bootstrap_evm_ipv6" {
 resource "cloudflare_record" "bootstrap_auto" {
   count   = length(local.bootstrap_nodes_autoid_ip_v4)
   zone_id = data.cloudflare_zone.cloudflare_zone.id
-  name    = "bootstrap-${count.index}.auto.${var.network_name}"
+  name    = "bootstrap-${count.index}.${var.domain-node-config.domain-prefix[1]}.${var.network_name}"
   value   = local.bootstrap_nodes_autoid_ip_v4[count.index]
   type    = "A"
 }
@@ -121,7 +121,7 @@ resource "cloudflare_record" "bootstrap_auto" {
 resource "cloudflare_record" "bootstrap_auto_ipv6" {
   count   = length(local.bootstrap_nodes_autoid_ip_v4)
   zone_id = data.cloudflare_zone.cloudflare_zone.id
-  name    = "bootstrap-${count.index}.auto.${var.network_name}"
+  name    = "bootstrap-${count.index}.${var.domain-node-config.domain-prefix[1]}.${var.network_name}"
   value   = local.bootstrap_nodes_autoid_ip_v6[count.index]
   type    = "AAAA"
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated domain prefixes from `nova` to `auto-evm` across multiple Terraform configuration files.
- Modified default domain labels to reflect the new `auto-evm` naming convention.
- Added `POT_EXTERNAL_ENTROPY` configuration to bootstrap node provisioners for both autoid and evm.
- Updated DNS record names to dynamically use the new domain prefixes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update domain prefixes for mainnet configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/mainnet/main.tf

<li>Updated <code>domain-prefix</code> from <code>nova-indexer</code> to <code>auto-evm-indexer</code>.<br> <li> Changed domain prefix list from <code>["nova", "autoid"]</code> to <code>["auto-evm", </code><br><code>"autoid"]</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-a57f3d48fbbd3295fb5660a99d5b91cce340a219f167f1c42ff2779d37a8853a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update default domain labels in variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/mainnet/variables.tf

<li>Modified default <code>domain_labels</code> from <code>["nova", "autoid"]</code> to <code>["auto-evm", </code><br><code>"autoid"]</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-7a31fd3644ce360c4bb509c81e5152609ddc343069a3a70f2f0f89da56434973">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update domain prefixes for taurus configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/taurus/main.tf

<li>Updated <code>domain-prefix</code> from <code>nova-indexer</code> to <code>auto-evm-indexer</code>.<br> <li> Changed domain prefix list from <code>["nova", "autoid"]</code> to <code>["auto-evm", </code><br><code>"autoid"]</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-6381ee5d5e3659ec44df9c0bbff42c0790c7e96aa5bc81ab2d1454707789973e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update default domain labels in taurus variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/taurus/variables.tf

<li>Modified default <code>domain_labels</code> from <code>["nova", "autoid"]</code> to <code>["auto-evm", </code><br><code>"autoid"]</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-0cecb2e3e29ddbbd53beb8181e688edf339ca505701b8e6cea9c1cb5d3eb5d4a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bootstrap_node_autoid_provisioner.tf</strong><dd><code>Add external entropy configuration to autoid bootstrap</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/network-primitives/bootstrap_node_autoid_provisioner.tf

- Added `POT_EXTERNAL_ENTROPY` to environment setup.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-5493f48206612a61842d7bed0d3b5ea2095b1af6bdbc22a5ab89cf078d3f778a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bootstrap_node_evm_provisioner.tf</strong><dd><code>Add external entropy configuration to evm bootstrap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/network-primitives/bootstrap_node_evm_provisioner.tf

- Added `POT_EXTERNAL_ENTROPY` to environment setup.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-faa8d3100407bc4203aee1847804d330c0c7942c87ccde5151250146c2986f95">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dns.tf</strong><dd><code>Use dynamic domain prefixes in DNS records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/network-primitives/dns.tf

- Updated DNS record names to use dynamic domain prefixes.



</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/385/files#diff-c810a352e5bab2e7bf254913677b4adf61d05a56713c09c668fe8c03431ecf90">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information