### PR TITLE
upgrade releases taurus and mainnet

### DIFF
--- a/explorer/terraform/aws/mainnet/main.tf
+++ b/explorer/terraform/aws/mainnet/main.tf
@@ -8,7 +8,7 @@ module "subql" {
     deployment-color    = "blue"
     network-name        = "${var.network_name}"
     domain-prefix       = "subql.blue"
-    docker-tag          = "mainnet-2024-nov-05"
+    docker-tag          = "mainnet-2024-dec-09"
     instance-type       = var.instance_type
     deployment-version  = 0
     regions             = var.aws_region
@@ -22,7 +22,7 @@ module "subql" {
     deployment-color     = "green"
     network-name         = "${var.network_name}"
     domain-prefix        = "subql.green"
-    docker-tag           = "mainnet-2024-nov-05"
+    docker-tag           = "mainnet-2024-dec-09"
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region
@@ -36,7 +36,7 @@ module "subql" {
     deployment-color    = "blue"
     network-name        = "${var.network_name}"
     domain-prefix       = "nova.subql.blue"
-    docker-tag          = "mainnet-2024-nov-05"
+    docker-tag          = "mainnet-2024-dec-09"
     instance-type       = var.instance_type
     deployment-version  = 0
     regions             = var.aws_region
@@ -50,7 +50,7 @@ module "subql" {
     deployment-color     = "green"
     network-name         = "${var.network_name}"
     domain-prefix        = "nova.subql.green"
-    docker-tag           = "mainnet-2024-nov-05"
+    docker-tag           = "mainnet-2024-dec-09"
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region

--- a/explorer/terraform/aws/taurus/main.tf
+++ b/explorer/terraform/aws/taurus/main.tf
@@ -8,7 +8,7 @@ module "subql" {
     deployment-color    = "blue"
     network-name        = "${var.network_name}"
     domain-prefix       = "subql.blue"
-    docker-tag          = "taurus-2024-nov-05"
+    docker-tag          = "taurus-2024-dec-03"
     instance-type       = var.instance_type
     deployment-version  = 0
     regions             = var.aws_region
@@ -22,7 +22,7 @@ module "subql" {
     deployment-color     = "green"
     network-name         = "${var.network_name}"
     domain-prefix        = "subql.green"
-    docker-tag           = "taurus-2024-nov-05"
+    docker-tag           = "taurus-2024-dec-03"
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region
@@ -36,7 +36,7 @@ module "subql" {
     deployment-color    = "blue"
     network-name        = "${var.network_name}"
     domain-prefix       = "nova.subql.blue"
-    docker-tag          = "taurus-2024-nov-05"
+    docker-tag          = "taurus-2024-dec-03"
     instance-type       = var.instance_type
     deployment-version  = 0
     regions             = var.aws_region
@@ -50,7 +50,7 @@ module "subql" {
     deployment-color     = "green"
     network-name         = "${var.network_name}"
     domain-prefix        = "nova.subql.green"
-    docker-tag           = "taurus-2024-nov-05"
+    docker-tag           = "taurus-2024-dec-03"
     instance-type        = var.instance_type
     deployment-version   = 0
     regions              = var.aws_region


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated `docker-tag` values in the Terraform configurations for both mainnet and taurus networks.
- Adjusted the `docker-tag` to reflect new release dates for blue, green, nova blue, and nova green subql node configurations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update docker tags for mainnet configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/terraform/aws/mainnet/main.tf

<li>Updated <code>docker-tag</code> values for blue and green subql node <br>configurations.<br> <li> Changed <code>docker-tag</code> for nova blue and nova green subql node <br>configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/386/files#diff-1b7ae5cfbea84eb9abaab0b7d14da16b80b1409d72d5a403dba680ed15113102">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update docker tags for taurus configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/terraform/aws/taurus/main.tf

<li>Updated <code>docker-tag</code> values for blue and green subql node <br>configurations.<br> <li> Changed <code>docker-tag</code> for nova blue and nova green subql node <br>configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/386/files#diff-120b23a7c7eeb4cae8061d0b8e1963f1c8a18c98da0cc5d15aac54123dc10322">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information