### PR TITLE
create HA Amazon MQ broker

### DIFF
--- a/auto-drive/broker.tf
+++ b/auto-drive/broker.tf
@@ -1,0 +1,223 @@
+resource "random_password" "rabbitmq_password" {
+  length           = 15
+  special          = true # Includes special characters
+  override_special = "!@#$%^&*()-_=+[]{}<>:?"
+}
+
+variable "private_subnet_cidrs" {
+  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+resource "aws_mq_broker" "rabbitmq_broker_primary" {
+  broker_name        = "auto-drive-rabbitmq-broker-primary"
+  engine_type        = "RabbitMQ"
+  engine_version     = var.rabbitmq_version
+  host_instance_type = var.rabbitmq_instance_type # t3.micro is the smallest instance type available for Amazon MQ, use mq.m5.large for production
+  security_groups    = [aws_security_group.rabbitmq_broker_primary.id]
+  deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
+  storage_type       = "ebs"
+  apply_immediately  = true
+
+  subnet_ids          = module.vpc.private_subnets # Use private subnets from VPC module
+  publicly_accessible = false
+  encryption_options {
+    use_aws_owned_key = false
+    kms_key_id        = aws_kms_key.mq_kms_key.arn
+  }
+
+  logs {
+    general = true
+    audit   = false
+  }
+
+  maintenance_window_start_time {
+    day_of_week = "Sunday"
+    time_of_day = "03:00"
+    time_zone   = "UTC"
+  }
+
+  user {
+    username = var.rabbitmq_username
+    password = random_password.rabbitmq_password.result
+  }
+
+  user {
+    username         = var.rabbitmq_replication_username
+    password         = random_password.rabbitmq_password.result
+    replication_user = true
+  }
+
+  tags = {
+    Environment = "Production"
+    Application = "AutoDrive"
+  }
+}
+
+resource "aws_mq_broker" "rabbitmq_broker_secondary" {
+  broker_name        = "auto-drive-rabbitmq-broker-secondary"
+  engine_type        = "RabbitMQ"
+  engine_version     = var.rabbitmq_version
+  host_instance_type = var.rabbitmq_instance_type # t3.micro is the smallest instance type available for Amazon MQ, use mq.m5.large for production
+  security_groups    = [aws_security_group.rabbitmq_broker_secondary.id]
+  deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
+  storage_type       = "ebs"
+  apply_immediately  = true
+
+  data_replication_mode               = "CRDR"
+  data_replication_primary_broker_arn = aws_mq_broker.rabbitmq_broker_primary.arn
+
+  subnet_ids          = module.vpc.private_subnets # Use private subnets from VPC module
+  publicly_accessible = false
+  encryption_options {
+    use_aws_owned_key = false
+    kms_key_id        = aws_kms_key.mq_kms_key.arn
+  }
+
+  logs {
+    general = true
+    audit   = false
+  }
+
+  maintenance_window_start_time {
+    day_of_week = "Sunday"
+    time_of_day = "04:00"
+    time_zone   = "UTC"
+  }
+
+  user {
+    username = var.rabbitmq_username
+    password = random_password.rabbitmq_password.result
+  }
+
+  user {
+    username         = var.rabbitmq_replication_username
+    password         = random_password.rabbitmq_password.result
+    replication_user = true
+  }
+
+  tags = {
+    Environment = "Production"
+    Application = "AutoDrive"
+  }
+}
+
+# Security Group for RabbitMQ Primary Broker
+resource "aws_security_group" "rabbitmq_broker_primary" {
+  name        = "rabbitmq-primary-sg"
+  description = "Security group for RabbitMQ primary broker"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 5671
+    to_port     = 5671
+    protocol    = "tcp"
+    cidr_blocks = var.private_subnet_cidrs
+  }
+
+  ingress {
+    from_port   = 5672
+    to_port     = 5672
+    protocol    = "tcp"
+    cidr_blocks = var.private_subnet_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "rabbitmq-primary-sg"
+  }
+}
+
+# Security Group for RabbitMQ Secondary Broker
+resource "aws_security_group" "rabbitmq_broker_secondary" {
+  name        = "rabbitmq-secondary-sg"
+  description = "Security group for RabbitMQ secondary broker"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 5671
+    to_port     = 5671
+    protocol    = "tcp"
+    cidr_blocks = var.private_subnet_cidrs
+  }
+
+  ingress {
+    from_port   = 5672
+    to_port     = 5672
+    protocol    = "tcp"
+    cidr_blocks = var.private_subnet_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "rabbitmq-secondary-sg"
+  }
+}
+
+# KMS Key for Encryption
+resource "aws_kms_key" "mq_kms_key" {
+  description             = "KMS key for RabbitMQ encryption"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+
+resource "aws_kms_alias" "mq_kms_alias" {
+  name          = "alias/rabbitmq-broker-key"
+  target_key_id = aws_kms_key.mq_kms_key.id
+}
+
+# IAM Role for CloudWatch Logging
+resource "aws_iam_role" "mq_cloudwatch_role" {
+  name               = "mq-cloudwatch-logs-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "mq.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "mq_cloudwatch_policy" {
+  name        = "mq-cloudwatch-logs-policy"
+  description = "Policy for allowing Amazon MQ to write logs to CloudWatch"
+  policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "mq_cloudwatch_attach" {
+  role       = aws_iam_role.mq_cloudwatch_role.name
+  policy_arn = aws_iam_policy.mq_cloudwatch_policy.arn
+}

--- a/auto-drive/outputs.tf
+++ b/auto-drive/outputs.tf
@@ -193,10 +193,11 @@ output "rabbitmq_primary_endpoint" {
   value       = aws_mq_broker.rabbitmq_broker_primary.instances[0].endpoints[0]
 }
 
-output "rabbitmq_secondary_endpoint" {
-  description = "Secondary RabbitMQ broker endpoint"
-  value       = aws_mq_broker.rabbitmq_broker_secondary.instances[0].endpoints[0]
-}
+# Data replication is only supported for activemq engine currently.
+# output "rabbitmq_secondary_endpoint" {
+#   description = "Secondary RabbitMQ broker endpoint"
+#   value       = aws_mq_broker.rabbitmq_broker_secondary.instances[0].endpoints[0]
+# }
 
 output "rabbitmq_instance_type" {
   description = "Instance type for RabbitMQ broker instances"

--- a/auto-drive/outputs.tf
+++ b/auto-drive/outputs.tf
@@ -186,3 +186,37 @@ output "db_instance_secretsmanager_secret_rotation_enabled" {
   description = "Specifies whether automatic rotation is enabled for the secret"
   value       = module.db.db_instance_secretsmanager_secret_rotation_enabled
 }
+
+# RabbitMQ Broker Outputs
+output "rabbitmq_primary_endpoint" {
+  description = "Primary RabbitMQ broker endpoint"
+  value       = aws_mq_broker.rabbitmq_broker_primary.instances[0].endpoints[0]
+}
+
+output "rabbitmq_secondary_endpoint" {
+  description = "Secondary RabbitMQ broker endpoint"
+  value       = aws_mq_broker.rabbitmq_broker_secondary.instances[0].endpoints[0]
+}
+
+output "rabbitmq_instance_type" {
+  description = "Instance type for RabbitMQ broker instances"
+  value       = var.rabbitmq_instance_type
+}
+
+output "rabbitmq_username" {
+  description = "RabbitMQ username"
+  value       = var.rabbitmq_username
+  sensitive   = true
+}
+
+output "rabbitmq_replication_username" {
+  description = "RabbitMQ replication username"
+  value       = var.rabbitmq_replication_username
+  sensitive   = true
+}
+
+output "rabbitmq_password" {
+  description = "RabbitMQ password"
+  value       = random_password.rabbitmq_password.result
+  sensitive   = true
+}

--- a/auto-drive/variables.tf
+++ b/auto-drive/variables.tf
@@ -124,5 +124,18 @@ variable "rabbitmq_instance_type" {
 variable "rabbitmq_version" {
   description = "RabbitMQ version."
   type        = string
-  default     = "3.10.10"
+  default     = "3.13"
+}
+
+variable "rabbitmq_deployment_mode_staging" {
+  description = "RabbitMQ deployment mode."
+  type        = string
+  default     = "SINGLE_INSTANCE"
+}
+
+
+variable "rabbitmq_deployment_mode_production" {
+  description = "RabbitMQ deployment mode."
+  type        = string
+  default     = "CLUSTER_MULTI_AZ"
 }

--- a/auto-drive/variables.tf
+++ b/auto-drive/variables.tf
@@ -100,3 +100,29 @@ variable "rules" {
     https = [443, 443, "tcp", "HTTPS access"]
   }
 }
+
+variable "rabbitmq_username" {
+  description = "RabbitMQ username"
+  type        = string
+  default     = "guru"
+  sensitive   = true
+}
+
+variable "rabbitmq_replication_username" {
+  description = "RabbitMQ replication username"
+  type        = string
+  default     = "guru2"
+  sensitive   = true
+}
+
+variable "rabbitmq_instance_type" {
+  description = "Instance type for RabbitMQ broker instances."
+  type        = string
+  default     = "mq.t3.micro"
+}
+
+variable "rabbitmq_version" {
+  description = "RabbitMQ version."
+  type        = string
+  default     = "3.10.10"
+}


### PR DESCRIPTION
### **User description**
Managed RabbitMQ with Amazon MQ with high-availability, replication and optimized EBS volume


___

### **PR Type**
Enhancement


___

### **Description**
- Added high-availability RabbitMQ brokers using Amazon MQ with multi-AZ deployment.

- Configured security groups, KMS encryption, and IAM roles for RabbitMQ.

- Introduced new variables and outputs for RabbitMQ configuration and access.

- Enabled logging and replication for RabbitMQ brokers.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>broker.tf</strong><dd><code>Added RabbitMQ broker resources and configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto-drive/broker.tf

<li>Added resources for primary and secondary RabbitMQ brokers.<br> <li> Configured security groups for RabbitMQ brokers.<br> <li> Added KMS key and alias for encryption.<br> <li> Defined IAM roles and policies for CloudWatch logging.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/412/files#diff-6891d00c1754641e405c6ec475d29714c308981f06e3f50714c092321ae7a1f7">+223/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Added RabbitMQ broker-related outputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto-drive/outputs.tf

<li>Added outputs for RabbitMQ broker endpoints.<br> <li> Included sensitive outputs for RabbitMQ credentials.<br> <li> Added output for RabbitMQ instance type.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/412/files#diff-f6b67ce53c1fc435c34dc1d277ef54561e3238eb3ce452d5d50b71b2f9f01234">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Introduced RabbitMQ-related variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto-drive/variables.tf

<li>Added variables for RabbitMQ usernames, instance type, and version.<br> <li> Marked sensitive variables for RabbitMQ credentials.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/412/files#diff-26930d4906da22bab52545f3aa09f57e171852b2eb63f2f07f12b02351dd229d">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>