### PR TITLE
add another public auto-drive instance

### DIFF
--- a/auto-drive/variables.tf
+++ b/auto-drive/variables.tf
@@ -70,7 +70,7 @@ variable "kms_key_id" {
 variable "auto_drive_instance_count" {
   description = "Number of auto-drive instances to create."
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "gateway_instance_count" {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Create a public auto-drive instance for anonymous downloads

- Increased default `auto_drive_instance_count` from 1 to 2.

- Updated Terraform variable to support additional auto-drive instance.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update default instance count for auto-drive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto-drive/variables.tf

<li>Changed the default value of <code>auto_drive_instance_count</code> from 1 to 2.<br> <li> Updated the variable to allow for an additional auto-drive instance.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/413/files#diff-26930d4906da22bab52545f3aa09f57e171852b2eb63f2f07f12b02351dd229d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>