### PR TITLE
vmetrics enable external URL

### DIFF
--- a/logging/victoriametrics/deployment/docker/docker-compose.yml
+++ b/logging/victoriametrics/deployment/docker/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - "--notifier.url=http://alertmanager:9093/"
       - "--rule=/etc/alerts/*.yml"
       # display source of alerts in grafana
-      - "--external.url=http://127.0.0.1:3300" #grafana outside container
+      - "--external.url=https://grafana.vmetrics.subspace.network" #grafana outside container
       - '--external.alert.source=explore?orgId=1&left={"datasource":"VictoriaMetrics","queries":[{"expr":{{.Expr|jsonEscape|queryEscape}},"refId":"A"}],"range":{"from":"{{ .ActiveAt.UnixMilli }}","to":"now"}}'
     restart: always
     networks:


### PR DESCRIPTION
### **User description**
This allows dashboards to be shared publicly


___

### **PR Type**
enhancement


___

### **Description**
- Updated the `external.url` to enable public sharing.

- Changed the URL to a secure external domain.

- Facilitates external access to Grafana dashboards.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update `external.url` for public Grafana access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

logging/victoriametrics/deployment/docker/docker-compose.yml

<li>Updated the <code>external.url</code> configuration.<br> <li> Changed the URL from localhost to a public domain.<br> <li> Ensures Grafana dashboards are accessible externally.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/422/files#diff-fa87a03bd72b198ad850b992a4d8a6ac3b8becb8560f27812ba98f9bc8090cf3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>