### PR TITLE
open ports for domain node syncing in firewall

### DIFF
--- a/templates/terraform/subql/base/network.tf
+++ b/templates/terraform/subql/base/network.tf
@@ -95,6 +95,30 @@ resource "aws_security_group" "subql-sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "TCP Node Port 30333 for VPC"
+    from_port   = 30333
+    to_port     = 30333
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "TCP Node Port 30433 for VPC"
+    from_port   = 30433
+    to_port     = 30433
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "TCP Node Port 30334 for VPC"
+    from_port   = 30334
+    to_port     = 30334
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     description = "egress for VPC"
     from_port   = 0


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add ingress rule for TCP port 30333 for VPC

- Add ingress rule for TCP port 30433 for VPC

- Add ingress rule for TCP port 30334 for VPC


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.tf</strong><dd><code>New ingress rules for node syncing ports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/terraform/subql/base/network.tf

<li>Added three ingress blocks for new node syncing ports<br> <li> Configured TCP ports 30333, 30433, and 30334


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/423/files#diff-adebabdbe43c9a44088554069066b65b850bb9a9568bc4ce1b13ae35f9e1e768">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>