### PR TITLE
upgrade taurus release 2025-march-05

### DIFF
--- a/resources/terraform/taurus/main.tf
+++ b/resources/terraform/taurus/main.tf
@@ -10,7 +10,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     reserved-only      = false
     prune              = false
     genesis-hash       = "295aeafca762a304d92ee1505548695091f6082d3f0aa4d092ac3cd6397a6c5e"
@@ -26,7 +26,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["evm_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     reserved-only      = false
     prune              = false
     genesis-hash       = "295aeafca762a304d92ee1505548695091f6082d3f0aa4d092ac3cd6397a6c5e"
@@ -43,7 +43,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["autoid_bootstrap"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     reserved-only      = false
     prune              = false
     genesis-hash       = "295aeafca762a304d92ee1505548695091f6082d3f0aa4d092ac3cd6397a6c5e"
@@ -60,7 +60,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc-indexer"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     domain-prefix      = "rpc-indexer"
     reserved-only      = false
     prune              = false
@@ -75,7 +75,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["nova-indexer"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     domain-prefix      = "auto-evm-indexer"
     reserved-only      = false
     prune              = false
@@ -93,7 +93,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["rpc"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     domain-prefix      = "rpc"
     reserved-only      = false
     prune              = false
@@ -108,7 +108,7 @@ module "taurus" {
     regions            = var.aws_region
     instance-count     = var.instance_count["domain"]
     docker-org         = "autonomys"
-    docker-tag         = "taurus-2025-jan-07"
+    docker-tag         = "taurus-2025-march-05"
     domain-prefix      = ["auto-evm", "autoid"]
     reserved-only      = false
     prune              = false
@@ -126,7 +126,7 @@ module "taurus" {
     regions                = var.aws_region
     instance-count         = var.instance_count["farmer"]
     docker-org             = "autonomys"
-    docker-tag             = "taurus-2025-jan-07"
+    docker-tag             = "taurus-2025-march-05"
     reserved-only          = false
     prune                  = false
     plot-size              = "10G"


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Updated docker-tag value for Taurus modules.

- Replaced "taurus-2025-jan-07" with "taurus-2025-march-05" across configurations.

- Ensured consistent release version in Terraform configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update docker tags to new Taurus release version.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/terraform/taurus/main.tf

<li>Replaced old docker-tag "taurus-2025-jan-07".<br> <li> Updated docker-tag to "taurus-2025-march-05" in all modules.<br> <li> Affected modules: bootstrap, evm_bootstrap, autoid_bootstrap, <br>rpc-indexer, nova-indexer, rpc, domain, farmer.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/424/files#diff-19e95209494e73722867d9fc74136d0a9b00dccd43acefb0c4e08cb57c4698d1">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>