### PR TITLE
add auth middleware to Loki

### DIFF
--- a/logging/grafana-loki/docker-compose.yml
+++ b/logging/grafana-loki/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - traefik.http.routers.loki.tls.certresolver=le
       - traefik.http.routers.loki.entrypoints=websecure
       - traefik.docker.network=traefik-proxy
+      - traefik.http.routers.loki.middlewares=loki-auth
+      - traefik.http.middlewares.loki-auth.basicauth.usersfile=/etc/traefik/loki-auth.txt
     volumes:
       - /root/loki/conf/loki/etc/loki-config.yaml:/etc/loki/loki-config.yaml:ro
     networks:

--- a/logging/traefik/docker-compose.yml
+++ b/logging/traefik/docker-compose.yml
@@ -27,3 +27,4 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/traefik/acme.json:/acme.json
+      - /root/loki/conf/loki-auth.txt:/etc/traefik/loki-auth.txt:ro


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Add authentication middleware configuration for Loki.

- Configure basic auth using a usersfile.

- Mount auth file for Traefik service.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Configure Loki service authentication middleware.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

logging/grafana-loki/docker-compose.yml

<li>Added middleware line: <br>traefik.http.routers.loki.middlewares=loki-auth.<br> <li> Configured basic auth with usersfile at /etc/traefik/loki-auth.txt.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/425/files#diff-ad8864801ea1033452af0de0c1e5106c730dd7a59ebdf4215f911b425d018408">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Mount authentication file in Traefik container.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

logging/traefik/docker-compose.yml

<li>Added volume mount for the loki-auth file at <br>/etc/traefik/loki-auth.txt.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/425/files#diff-4a19a00e12e849aecb373ca86f2f3bbc4d9e2ebcb8a1e944986a1218e8590bb5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>