### PR TITLE
reduce AD instances

### DIFF
--- a/resources/terraform/auto-drive/variables.tf
+++ b/resources/terraform/auto-drive/variables.tf
@@ -77,7 +77,7 @@ variable "kms_key_id" {
 variable "auto_drive_instance_count" {
   description = "Number of auto-drive instances to create."
   type        = number
-  default     = 3
+  default     = 2
 }
 
 variable "gateway_instance_count" {


### PR DESCRIPTION
in #426 accidentally added an additional AD instance, but it's not needed since we have a separate module for the taurus public instance.