### PR TITLE
enable RabbitMQ web management console

### DIFF
--- a/resources/terraform/auto-drive/broker.tf
+++ b/resources/terraform/auto-drive/broker.tf
@@ -115,6 +115,14 @@ resource "aws_security_group" "rabbitmq_broker_primary" {
     security_groups = [aws_security_group.auto_drive_sg.id] # Allow traffic from EC2 server's security group
   }
 
+  # enable RabbitMQ web management console (only accessible from the VPC)
+  ingress {
+    from_port       = 15671
+    to_port         = 15671
+    protocol        = "tcp"
+    security_groups = [aws_security_group.auto_drive_sg.id] # Allow traffic from EC2 server's security group
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
### **User description**
Only accessible from inside the VPC for security.


___

### **PR Type**
Enhancement


___

### **Description**
- Added ingress rule for RabbitMQ console web management port

- Restricted access using internal VPC security group


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>broker.tf</strong><dd><code>Add ingress for RabbitMQ console web management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/terraform/auto-drive/broker.tf

<li>Added ingress rule for port 15671 for web console<br> <li> Ensured access only from internal EC2 security group


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/429/files#diff-d98b488b8db1e78031f02d1459091059f2d40f575a5e42b4c1ebb03118322c43">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>