### PR TITLE
fix: terraform add outputs multi-network gateway and taurus AD

### DIFF
--- a/resources/terraform/auto-drive/outputs.tf
+++ b/resources/terraform/auto-drive/outputs.tf
@@ -1,5 +1,5 @@
 ################################################################################
-# Auto-Drive Instances Outputs
+# Mainnet Auto-Drive Instances Outputs
 ################################################################################
 
 output "ec2_auto_drive_ids" {
@@ -30,6 +30,40 @@ output "ec2_auto_drive_public_ips" {
 output "ec2_auto_drive_availability_zones" {
   description = "The availability zones of the auto-drive instances"
   value       = module.ec2_auto_drive[*].availability_zone
+}
+
+################################################################################
+# Taurus Auto-Drive Instances Outputs
+################################################################################
+
+output "ec2_auto_drive_taurus_ids" {
+  description = "The IDs of the auto-drive instances"
+  value       = module.ec2_auto_drive_taurus[*].id
+}
+
+output "ec2_auto_drive_taurus_arns" {
+  description = "The ARNs of the auto-drive instances"
+  value       = module.ec2_auto_drive_taurus[*].arn
+}
+
+output "ec2_auto_drive_taurus_instance_states" {
+  description = "The states of the auto-drive instances (e.g., pending, running, etc.)"
+  value       = module.ec2_auto_drive_taurus[*].instance_state
+}
+
+output "ec2_auto_drive_taurus_private_ips" {
+  description = "The private IPs of the auto-drive instances"
+  value       = module.ec2_auto_drive_taurus[*].private_ip
+}
+
+output "ec2_auto_drive_taurus_public_ips" {
+  description = "The public IPs of the auto-drive instances, if applicable"
+  value       = module.ec2_auto_drive_taurus[*].public_ip
+}
+
+output "ec2_auto_drive_taurus_availability_zones" {
+  description = "The availability zones of the auto-drive instances"
+  value       = module.ec2_auto_drive_taurus[*].availability_zone
 }
 
 ################################################################################
@@ -76,6 +110,39 @@ output "gateway_eip" {
   value       = module.ec2_gateway[*].public_ip
 }
 
+################################################################################
+# Multi Network Gateway Instances Outputs
+################################################################################
+
+output "ec2_multi_gateway_ids" {
+  description = "The IDs of the gateway instances"
+  value       = module.ec2_multi_gateway[*].id
+}
+
+output "ec2_multi_gateway_arns" {
+  description = "The ARNs of the gateway instances"
+  value       = module.ec2_multi_gateway[*].arn
+}
+
+output "ec2_multi_gateway_instance_states" {
+  description = "The states of the gateway instances (e.g., pending, running, etc.)"
+  value       = module.ec2_multi_gateway[*].instance_state
+}
+
+output "ec2_multi_gateway_private_ips" {
+  description = "The private IPs of the gateway instances"
+  value       = module.ec2_multi_gateway[*].private_ip
+}
+
+output "ec2_multi_gateway_public_ips" {
+  description = "The public IPs of the gateway instances, if applicable"
+  value       = module.ec2_multi_gateway[*].public_ip
+}
+
+output "ec2_multi_gateway_availability_zones" {
+  description = "The availability zones of the gateway instances"
+  value       = module.ec2_multi_gateway[*].availability_zone
+}
 
 ################################################################################
 # RDS Outputs


### PR DESCRIPTION
### **User description**
Follow up on #426 and add output variables  to terraform resources


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced Taurus auto-drive outputs.

- Added multi-network gateway outputs.

- Renamed header for mainnet auto-drive instances.

- Updated gateway EIP to use multi-network module.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Update outputs with Taurus and multi-network gateway blocks</code></dd></summary>
<hr>

resources/terraform/auto-drive/outputs.tf

<li>Changed header comment to "Mainnet Auto-Drive Instances Outputs".<br> <li> Added Taurus auto-drive outputs: IDs, ARNs, states, private/public <br>IPs, availability zones.<br> <li> Added multi-network gateway outputs: IDs, ARNs, states, private/public <br>IPs, availability zones.<br> <li> Updated gateway EIP output reference.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/430/files#diff-31834467f279d8cafc1dfa09f2e4198e0093921b769e0811e0621d3a57eacd81">+74/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>