### PR TITLE
change taurus machine types

### DIFF
--- a/resources/terraform/taurus/variables.tf
+++ b/resources/terraform/taurus/variables.tf
@@ -32,8 +32,8 @@ variable "instance_type" {
     rpc-indexer      = "c7a.4xlarge"
     nova-indexer     = "c7a.4xlarge"
     farmer           = "c7a.2xlarge"
-    evm_bootstrap    = "c7a.xlarge"
-    autoid_bootstrap = "c7a.xlarge"
+    evm_bootstrap    = "m7a.xlarge"
+    autoid_bootstrap = "m7a.xlarge"
   }
 }
 


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Changed instance type values for evm_bootstrap and autoid_bootstrap.

- Standardized to use m7a.xlarge for Taurus configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update Taurus instance types in variables configuration.</code>&nbsp; </dd></summary>
<hr>

resources/terraform/taurus/variables.tf

<li>Updated default instance type map for Taurus.<br> <li> Replaced c7a.xlarge with m7a.xlarge for evm_bootstrap.<br> <li> Replaced c7a.xlarge with m7a.xlarge for autoid_bootstrap.


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/432/files#diff-0051523a77373ad05649a7151bb7721984ea7b779be0acbe27d065bd331b3424">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>