### PR TITLE
Allow taurus AD private instance access to broker

### DIFF
--- a/resources/terraform/auto-drive/broker.tf
+++ b/resources/terraform/auto-drive/broker.tf
@@ -123,6 +123,24 @@ resource "aws_security_group" "rabbitmq_broker_primary" {
     security_groups = [aws_security_group.auto_drive_sg.id] # Allow traffic from EC2 server's security group
   }
 
+  # Allow from specific external IP address temporarily for testing purposes
+  ingress {
+    from_port   = 5671
+    to_port     = 5671
+    protocol    = "tcp"
+    cidr_blocks = ["136.243.147.181/32"]
+    description = "Allow RabbitMQ access from external IP"
+  }
+
+  # Allow from specific external IP address temporarily for testing purposes
+  ingress {
+    from_port   = 5672
+    to_port     = 5672
+    protocol    = "tcp"
+    cidr_blocks = ["136.243.147.181/32"]
+    description = "Allow RabbitMQ access from external IP"
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/resources/terraform/auto-drive/variables.tf
+++ b/resources/terraform/auto-drive/variables.tf
@@ -58,7 +58,7 @@ variable "multi_network_gateway_instance_type" {
 variable "gateway_root_volume_size" {
   description = "Size of the root volume (in GB) for gateway instances."
   type        = number
-  default     = 150
+  default     = 250
 }
 
 variable "iam_role_policy_arn" {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add temporary ingress rule for external IP

- Permit RabbitMQ access on port 5671/5672

- Annotate rule for testing purposes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>broker.tf`</strong><dd><code>Add external IP access to RabbitMQ UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`resources/terraform/auto-drive/broker.tf`

<li>Insert new <code>ingress</code> block for testing<br> <li> Permit port <code>15671</code> from <code>136.243.147.181/32</code><br> <li> Add <code>description</code> for external access


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>broker.tf</strong></td>
  <td><a href="https://github.com/autonomys/infra/pull/438/files#diff-d98b488b8db1e78031f02d1459091059f2d40f575a5e42b4c1ebb03118322c43">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>