### PR TITLE
remove external IP access for security

### DIFF
--- a/resources/terraform/auto-drive/broker.tf
+++ b/resources/terraform/auto-drive/broker.tf
@@ -123,24 +123,6 @@ resource "aws_security_group" "rabbitmq_broker_primary" {
     security_groups = [aws_security_group.auto_drive_sg.id] # Allow traffic from EC2 server's security group
   }
 
-  # Allow from specific external IP address temporarily for testing purposes
-  ingress {
-    from_port   = 5671
-    to_port     = 5671
-    protocol    = "tcp"
-    cidr_blocks = ["136.243.147.181/32"]
-    description = "Allow RabbitMQ access from external IP"
-  }
-
-  # Allow from specific external IP address temporarily for testing purposes
-  ingress {
-    from_port   = 5672
-    to_port     = 5672
-    protocol    = "tcp"
-    cidr_blocks = ["136.243.147.181/32"]
-    description = "Allow RabbitMQ access from external IP"
-  }
-
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
### **User description**
revert #438


___

### **PR Type**
Bug fix


___

### **Description**
Remove temporary external IP ingress rules
Tighten RabbitMQ broker security group


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>broker.tf</strong><dd><code>Remove RabbitMQ external IP ingress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/terraform/auto-drive/broker.tf

<li>Removed ingress rule for port 5671<br> <li> Removed ingress rule for port 5672<br> <li> Deleted temporary testing CIDR block


</details>


  </td>
  <td><a href="https://github.com/autonomys/infra/pull/439/files#diff-d98b488b8db1e78031f02d1459091059f2d40f575a5e42b4c1ebb03118322c43">+0/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>