### PR TITLE
Add CNAME DNS record for explorer.ai3.storage

### DIFF
--- a/resources/terraform/dns/ai3_storage.tf
+++ b/resources/terraform/dns/ai3_storage.tf
@@ -18,3 +18,13 @@ resource "cloudflare_dns_record" "ai3_storage_auto_drive_demo" {
   settings = {}
 }
 
+resource "cloudflare_dns_record" "ai3_storage_auto_drive_explorer" {
+  content  = "auto-drive-storage.netlify.app"
+  name     = "explorer.ai3.storage"
+  proxied  = false
+  ttl      = 1
+  type     = "CNAME"
+  zone_id  = data.cloudflare_zone.ai3_storage.zone_id
+  settings = {}
+}
+


### PR DESCRIPTION
Added new CNAME record that points:

explorer -> [auto-drive-storage.netlify.app](https://auto-drive-storage.netlify.app)

The current site is still the app w/ landing but will updated shortly

@jfrank-summit @vedhavyas 