### PR TITLE
Update CNAME record for www.autonomys.xyz to new Webflow address

### DIFF
--- a/resources/terraform/dns/autonomys_xyz.tf
+++ b/resources/terraform/dns/autonomys_xyz.tf
@@ -935,7 +935,7 @@ resource "cloudflare_dns_record" "terraform_managed_resource_ccd372ab4b77ee2f760
 
 
 resource "cloudflare_dns_record" "terraform_managed_resource_55fcac1d820fb9064253f3dc23c1774c_118" {
-  content = "proxy-ssl.webflow.com"
+  content = "cdn.webflow.com"
   name    = "www.autonomys.xyz"
   proxied = false
   tags    = []


### PR DESCRIPTION
As per instructions from Webflow:

> We’re upgrading our infrastructure— update your domains to maximize site performance
> 
> Update your site’s domains by December 15, 2025 for the best security and reliability. You can use the buttons to bulk update domains or update them manually. To update manually, visit the admin console of your domain registrar (the website you purchased your domain from) and update the CNAME record to cdn.webflow.com. It may take up to 48 hours for changes to take effect.