### PR TITLE
Add 0xAutonomys infrastructure to Terraform

### DIFF
--- a/resources/terraform/0xautonomys/README.md
+++ b/resources/terraform/0xautonomys/README.md
@@ -1,0 +1,202 @@
+# 0xAutonomys Infrastructure
+
+Terraform project for the **0xAutonomys** EC2 instance — an [OpenClaw](https://openclaw.ai) AI agent running on AWS.
+
+## What This Manages
+
+### Automated (Terraform)
+
+| Resource | Description |
+|----------|-------------|
+| `aws_instance.this` | t3.medium EC2, Ubuntu 24.04 LTS, 20GB gp3 |
+| `aws_security_group.this` | SSH ingress (currently open), all egress |
+| `aws_eip.this` | Elastic IP for stable public address |
+
+### Automated (cloud-init, first boot only)
+
+The `cloud-init.yaml` configures the OS on first boot:
+
+- Hostname (`0xautonomys`) and timezone (UTC)
+- SSH hardening (no root login, no password auth, key-only)
+- UFW firewall (deny incoming, allow SSH + all outbound)
+- fail2ban (sshd jail, 1h ban, 5 retries)
+- Unattended security upgrades (auto-reboot disabled)
+- Disable unused services (ModemManager, multipathd, fwupd, packagekit)
+- journald log rotation (500MB max, 30 day retention)
+- `autonomys` service user with sudoers entry and SSH key
+- System Node.js 22 via NodeSource
+- Linger enabled for `autonomys` user (systemd user services)
+
+### Not Automated (manual steps after provisioning)
+
+These require interactive setup or contain secrets:
+
+1. **nvm + Node.js 24** — Install under `autonomys` user
+2. **OpenClaw** — `npm install -g openclaw && openclaw onboard` (interactive wizard)
+3. **`.env` file** — Create at `/home/autonomys/.openclaw/.env` (chmod 600)
+4. **systemd override** — Drop-in for EnvironmentFile
+5. **openclaw symlink** — `/usr/local/bin/openclaw` -> nvm binary
+6. **Telegram pairing** — Via OpenClaw onboarding
+7. **Google OAuth** — Client secret JSON at `/home/autonomys/.openclaw/credentials/`
+8. **Workspace files** — `SOUL.md`, `HEARTBEAT.md`, skills
+9. **Cron job** — Disk usage alert via Telegram (under `ubuntu` user)
+
+## Prerequisites
+
+- Terraform >= 1.5
+- AWS credentials with EC2/VPC/EIP permissions
+- Terraform Cloud access (org: `subspace-sre`)
+- Infisical credentials (for `manage.sh` workflow)
+- SSH key pair `0xautonomys` already registered in AWS (private key in password manager)
+
+## Setup
+
+### 1. Create Terraform Cloud Workspace
+
+Create a workspace named `0xautonomys` in the `subspace-sre` org. Set execution mode to **Local**.
+
+### 2. Configure Secrets
+
+```bash
+# Copy the example and fill in AWS credentials
+cp common.auto.tfvars.example common.auto.tfvars
+# Edit common.auto.tfvars with your AWS access key and secret key
+```
+
+Or use the manage.sh workflow:
+
+```bash
+../../manage.sh 0xautonomys fetch-secrets
+```
+
+### 3. Import Existing Resources
+
+The instance is already running. Import rather than create:
+
+```bash
+terraform init
+
+# Import the EC2 instance
+terraform import aws_instance.this <instance-id>
+
+# Import the security group
+terraform import aws_security_group.this <sg-id>
+
+# Import the SG rules (get rule IDs with:
+#   aws ec2 describe-security-group-rules \
+#     --filters Name=group-id,Values=<sg-id> --region us-east-2 --profile 0xautonomys)
+terraform import 'aws_vpc_security_group_ingress_rule.ssh["0.0.0.0/0"]' <ingress-sgr-id>
+terraform import aws_vpc_security_group_egress_rule.all <egress-sgr-id>
+
+# Import the Elastic IP
+terraform import aws_eip.this <eipalloc-id>
+```
+
+### 4. Check for Drift
+
+```bash
+terraform plan
+```
+
+If the plan shows **no changes**, the spec matches reality.
+
+### 5. Apply (when ready)
+
+```bash
+terraform apply
+```
+
+## Post-Provision Manual Steps
+
+After Terraform provisioning (or on an existing instance), complete these steps as the `autonomys` user:
+
+```bash
+# SSH in as autonomys
+ssh 0xautonomys-agent
+
+# 1. Install nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.bashrc
+
+# 2. Install Node.js 24 (LTS)
+nvm install 24
+
+# 3. Install OpenClaw
+npm install -g openclaw
+
+# 4. Create the symlink (as ubuntu user, with sudo)
+# ssh 0xautonomys
+# sudo ln -sf /home/autonomys/.nvm/versions/node/v24.x.x/bin/openclaw /usr/local/bin/openclaw
+
+# 5. Run onboarding (interactive)
+openclaw onboard
+# - Select gateway mode
+# - Configure Telegram channel
+# - Set model to anthropic/claude-sonnet-4-6
+
+# 6. Create .env file
+cat > ~/.openclaw/.env << 'EOF'
+ANTHROPIC_API_KEY=<secret>
+TELEGRAM_BOT_TOKEN=<secret>
+TELEGRAM_APPROVAL_CHAT_ID=<secret>
+AUTO_DRIVE_API_KEY=<secret>
+GOOGLE_CLIENT_ID=<secret>
+GOOGLE_CLIENT_SECRET=<secret>
+EOF
+chmod 600 ~/.openclaw/.env
+
+# 7. Add systemd override for EnvironmentFile
+mkdir -p ~/.config/systemd/user/openclaw-gateway.service.d
+cat > ~/.config/systemd/user/openclaw-gateway.service.d/override.conf << 'EOF'
+[Service]
+EnvironmentFile=%h/.openclaw/.env
+EOF
+systemctl --user daemon-reload
+systemctl --user restart openclaw-gateway
+
+# 8. Place workspace files
+# - ~/.openclaw/workspace/SOUL.md
+# - ~/.openclaw/workspace/HEARTBEAT.md
+# - ~/.openclaw/workspace/skills/auto-drive/
+
+# 9. Set up cron job (as ubuntu user, not autonomys)
+# ssh 0xautonomys
+# crontab -e
+# Add disk usage alert (see spec for full cron line)
+
+# 10. Google OAuth setup
+# Place client_secret_*.json in ~/.openclaw/credentials/
+```
+
+## Secrets Reference
+
+These secrets are NOT stored in the repo. They must be provisioned manually:
+
+| Secret | Location | Source |
+|--------|----------|--------|
+| AWS credentials | `common.auto.tfvars` | Infisical |
+| SSH private key | `~/.ssh/0xautonomys.pem` | Password manager |
+| `ANTHROPIC_API_KEY` | `.openclaw/.env` | Anthropic console |
+| `TELEGRAM_BOT_TOKEN` | `.openclaw/.env` | BotFather |
+| `AUTO_DRIVE_API_KEY` | `.openclaw/.env` | Auto Drive |
+| `GOOGLE_CLIENT_ID` | `.openclaw/.env` | Google Cloud console |
+| `GOOGLE_CLIENT_SECRET` | `.openclaw/.env` | Google Cloud console |
+| Google OAuth JSON | `.openclaw/credentials/` | Google Cloud console |
+
+## Validation
+
+Run `validate.sh` to verify the live instance matches the spec:
+
+```bash
+./validate.sh              # uses SSH host "0xautonomys"
+./validate.sh 0xautonomys  # explicit host
+```
+
+This checks OS-level configuration (SSH hardening, UFW, fail2ban, users, Node.js, OpenClaw service, workspace files). Use alongside `terraform plan` which checks AWS-level resources.
+
+## Security Notes
+
+- SSH is currently open to `0.0.0.0/0` because not all operators have static IPs. Security relies on key-only auth + fail2ban.
+- Consider AWS Systems Manager Session Manager as an alternative to direct SSH exposure.
+- The `.env` file is chmod 600 and owned by the `autonomys` user.
+- IMDSv2 is enforced (`http_tokens = "required"`).

--- a/resources/terraform/0xautonomys/README.md
+++ b/resources/terraform/0xautonomys/README.md
@@ -66,9 +66,9 @@ cp user.auto.tfvars.example user.auto.tfvars
 ### 3. Plan and Apply
 
 ```bash
-terraform init
-terraform plan
-terraform apply
+./resources/terraform/manage.sh 0xautonomys init
+./resources/terraform/manage.sh 0xautonomys plan
+./resources/terraform/manage.sh 0xautonomys apply
 ```
 
 ## Post-Provision Manual Steps

--- a/resources/terraform/0xautonomys/README.md
+++ b/resources/terraform/0xautonomys/README.md
@@ -46,7 +46,6 @@ These require interactive setup or contain secrets:
 - Terraform >= 1.5
 - AWS credentials with EC2/VPC/EIP permissions
 - Terraform Cloud access (org: `subspace-sre`)
-- Infisical credentials (for `manage.sh` workflow)
 - SSH key pair `0xautonomys` already registered in AWS (private key in password manager)
 
 ## Setup
@@ -57,23 +56,19 @@ Create a workspace named `0xautonomys` in the `subspace-sre` org. Set execution 
 
 ### 2. Configure Secrets
 
-```bash
-# Copy the example and fill in AWS credentials
-cp common.auto.tfvars.example common.auto.tfvars
-# Edit common.auto.tfvars with your AWS access key and secret key
-```
-
-Or use the manage.sh workflow:
+Create `user.auto.tfvars` with your AWS credentials:
 
 ```bash
-../../manage.sh 0xautonomys fetch-secrets
+cp user.auto.tfvars.example user.auto.tfvars
+# Edit user.auto.tfvars with your AWS access key, secret key, and subnet ID
 ```
 
 ### 3. Plan and Apply
 
 ```bash
-../../manage.sh 0xautonomys plan
-../../manage.sh 0xautonomys apply
+terraform init
+terraform plan
+terraform apply
 ```
 
 ## Post-Provision Manual Steps

--- a/resources/terraform/0xautonomys/README.md
+++ b/resources/terraform/0xautonomys/README.md
@@ -69,41 +69,11 @@ Or use the manage.sh workflow:
 ../../manage.sh 0xautonomys fetch-secrets
 ```
 
-### 3. Import Existing Resources
-
-The instance is already running. Import rather than create:
+### 3. Plan and Apply
 
 ```bash
-terraform init
-
-# Import the EC2 instance
-terraform import aws_instance.this <instance-id>
-
-# Import the security group
-terraform import aws_security_group.this <sg-id>
-
-# Import the SG rules (get rule IDs with:
-#   aws ec2 describe-security-group-rules \
-#     --filters Name=group-id,Values=<sg-id> --region us-east-2 --profile 0xautonomys)
-terraform import 'aws_vpc_security_group_ingress_rule.ssh["0.0.0.0/0"]' <ingress-sgr-id>
-terraform import aws_vpc_security_group_egress_rule.all <egress-sgr-id>
-
-# Import the Elastic IP
-terraform import aws_eip.this <eipalloc-id>
-```
-
-### 4. Check for Drift
-
-```bash
-terraform plan
-```
-
-If the plan shows **no changes**, the spec matches reality.
-
-### 5. Apply (when ready)
-
-```bash
-terraform apply
+../../manage.sh 0xautonomys plan
+../../manage.sh 0xautonomys apply
 ```
 
 ## Post-Provision Manual Steps

--- a/resources/terraform/0xautonomys/backend.tf
+++ b/resources/terraform/0xautonomys/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "subspace-sre"
+
+    workspaces {
+      name = "0xautonomys"
+    }
+  }
+}

--- a/resources/terraform/0xautonomys/cloud-init.yaml
+++ b/resources/terraform/0xautonomys/cloud-init.yaml
@@ -1,0 +1,91 @@
+#cloud-config
+
+hostname: 0xautonomys
+timezone: UTC
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - fail2ban
+  - ufw
+  - unattended-upgrades
+  - curl
+  - apt-transport-https
+  - ca-certificates
+  - jq
+
+write_files:
+  - path: /etc/ssh/sshd_config.d/99-hardening.conf
+    content: |
+      PermitRootLogin no
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      PubkeyAuthentication yes
+      AuthorizedKeysFile .ssh/authorized_keys
+    permissions: "0644"
+
+  - path: /etc/fail2ban/jail.local
+    content: |
+      [sshd]
+      enabled = true
+      bantime = 1h
+      findtime = 10m
+      maxretry = 5
+    permissions: "0644"
+
+  - path: /etc/apt/apt.conf.d/50unattended-upgrades-local
+    content: |
+      Unattended-Upgrade::Automatic-Reboot "false";
+    permissions: "0644"
+
+  - path: /etc/systemd/journald.conf.d/openclaw.conf
+    content: |
+      [Journal]
+      SystemMaxUse=500M
+      SystemKeepFree=1G
+      MaxRetentionSec=30day
+    permissions: "0644"
+
+runcmd:
+  - systemctl restart sshd
+
+  # UFW
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 22/tcp
+  - ufw --force enable
+
+  # fail2ban
+  - systemctl enable fail2ban
+  - systemctl start fail2ban
+
+  # Disable unnecessary services
+  - systemctl disable --now ModemManager 2>/dev/null || true
+  - systemctl disable --now multipathd 2>/dev/null || true
+  - systemctl disable --now fwupd 2>/dev/null || true
+  - systemctl disable --now packagekit 2>/dev/null || true
+
+  # Create autonomys service user
+  - useradd -m -s /bin/bash autonomys
+
+  # Sudoers: allow ubuntu to run commands as autonomys
+  - echo 'ubuntu ALL=(autonomys) NOPASSWD: ALL' > /etc/sudoers.d/ubuntu-to-autonomys
+  - chmod 0440 /etc/sudoers.d/ubuntu-to-autonomys
+
+  # Copy SSH authorized_keys so the same key can log in as autonomys
+  - mkdir -p /home/autonomys/.ssh
+  - cp /home/ubuntu/.ssh/authorized_keys /home/autonomys/.ssh/authorized_keys
+  - chown -R autonomys:autonomys /home/autonomys/.ssh
+  - chmod 700 /home/autonomys/.ssh
+  - chmod 600 /home/autonomys/.ssh/authorized_keys
+
+  # Enable linger for systemd user services without active login
+  - loginctl enable-linger autonomys
+
+  # System Node.js 22 via NodeSource (satisfies openclaw doctor requirement)
+  - curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  - apt-get install -y nodejs
+
+  # Apply journald config
+  - systemctl restart systemd-journald

--- a/resources/terraform/0xautonomys/common.auto.tfvars.example
+++ b/resources/terraform/0xautonomys/common.auto.tfvars.example
@@ -1,4 +1,0 @@
-aws_access_key = ""
-aws_secret_key = ""
-vpc_id         = ""
-subnet_id      = ""

--- a/resources/terraform/0xautonomys/common.auto.tfvars.example
+++ b/resources/terraform/0xautonomys/common.auto.tfvars.example
@@ -1,0 +1,4 @@
+aws_access_key = ""
+aws_secret_key = ""
+vpc_id         = ""
+subnet_id      = ""

--- a/resources/terraform/0xautonomys/main.tf
+++ b/resources/terraform/0xautonomys/main.tf
@@ -62,7 +62,7 @@ resource "aws_vpc_security_group_egress_rule" "all" {
   cidr_ipv4         = "0.0.0.0/0"
 }
 
-resource "aws_instance" "this" {
+resource "aws_instance" "zeroxautonomys" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_type
   key_name                    = var.key_name
@@ -95,7 +95,7 @@ resource "aws_instance" "this" {
 }
 
 resource "aws_eip" "this" {
-  instance = aws_instance.this.id
+  instance = aws_instance.zeroxautonomys.id
   domain   = "vpc"
 
   tags = {

--- a/resources/terraform/0xautonomys/main.tf
+++ b/resources/terraform/0xautonomys/main.tf
@@ -1,0 +1,104 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+locals {
+  subnet_id = var.subnet_id != "" ? var.subnet_id : data.aws_subnets.default.ids[0]
+}
+
+resource "aws_security_group" "this" {
+  name        = var.security_group_name
+  description = "launch-wizard-4 created 2026-02-20T13:33:55.696Z"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "0xautonomys"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh" {
+  for_each = toset(var.ssh_allowed_cidrs)
+
+  security_group_id = aws_security_group.this.id
+  description       = "SSH access"
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.this.id
+  description       = "All outbound traffic"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_instance" "this" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  vpc_security_group_ids      = [aws_security_group.this.id]
+  subnet_id                   = local.subnet_id
+  associate_public_ip_address = true
+  ebs_optimized               = true
+
+  user_data = file("${path.module}/cloud-init.yaml")
+
+  root_block_device {
+    volume_size           = var.volume_size
+    volume_type           = "gp3"
+    iops                  = 3000
+    throughput            = 125
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name = "0xautonomys"
+  }
+
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+}
+
+resource "aws_eip" "this" {
+  instance = aws_instance.this.id
+  domain   = "vpc"
+
+  tags = {
+    Name = "0xautonomys"
+  }
+}

--- a/resources/terraform/0xautonomys/outputs.tf
+++ b/resources/terraform/0xautonomys/outputs.tf
@@ -1,6 +1,6 @@
 output "instance_id" {
   description = "EC2 instance ID"
-  value       = aws_instance.this.id
+  value       = aws_instance.zeroxautonomys.id
 }
 
 output "public_ip" {
@@ -10,7 +10,7 @@ output "public_ip" {
 
 output "private_ip" {
   description = "Private IP address"
-  value       = aws_instance.this.private_ip
+  value       = aws_instance.zeroxautonomys.private_ip
 }
 
 output "security_group_id" {
@@ -20,10 +20,10 @@ output "security_group_id" {
 
 output "instance_state" {
   description = "Current instance state"
-  value       = aws_instance.this.instance_state
+  value       = aws_instance.zeroxautonomys.instance_state
 }
 
 output "availability_zone" {
   description = "Availability zone of the instance"
-  value       = aws_instance.this.availability_zone
+  value       = aws_instance.zeroxautonomys.availability_zone
 }

--- a/resources/terraform/0xautonomys/outputs.tf
+++ b/resources/terraform/0xautonomys/outputs.tf
@@ -1,0 +1,29 @@
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.this.id
+}
+
+output "public_ip" {
+  description = "Elastic IP address"
+  value       = aws_eip.this.public_ip
+}
+
+output "private_ip" {
+  description = "Private IP address"
+  value       = aws_instance.this.private_ip
+}
+
+output "security_group_id" {
+  description = "Security group ID"
+  value       = aws_security_group.this.id
+}
+
+output "instance_state" {
+  description = "Current instance state"
+  value       = aws_instance.this.instance_state
+}
+
+output "availability_zone" {
+  description = "Availability zone of the instance"
+  value       = aws_instance.this.availability_zone
+}

--- a/resources/terraform/0xautonomys/providers.tf
+++ b/resources/terraform/0xautonomys/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.17"
+    }
+  }
+}
+
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.region
+}

--- a/resources/terraform/0xautonomys/user.auto.tfvars.example
+++ b/resources/terraform/0xautonomys/user.auto.tfvars.example
@@ -1,0 +1,2 @@
+aws_access_key = ""
+aws_secret_key = ""

--- a/resources/terraform/0xautonomys/validate.sh
+++ b/resources/terraform/0xautonomys/validate.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Verify that the live 0xautonomys instance matches the infrastructure spec.
+# Usage: ./validate.sh [ssh-host]
+#   ssh-host defaults to "0xautonomys" (must be configured in ~/.ssh/config)
+set -euo pipefail
+
+HOST="${1:-0xautonomys}"
+ERRORS=0
+PASS=0
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+check() {
+  local desc="$1" cmd="$2" expected="$3"
+  result=$(ssh -o ConnectTimeout=5 "$HOST" "$cmd" 2>/dev/null || echo "COMMAND_FAILED")
+  if [[ "$result" == *"$expected"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "        expected: '$expected'"
+    echo "        got:      '$result'"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+echo "=== Validating $HOST ==="
+echo ""
+
+# --- Instance basics ---
+echo "[Instance]"
+check "Hostname" "hostname" "0xautonomys"
+check "Timezone" "timedatectl show -p Timezone --value" "UTC"
+check "Ubuntu 24.04" "lsb_release -rs" "24.04"
+
+# --- SSH hardening ---
+echo ""
+echo "[SSH Hardening]"
+check "PermitRootLogin disabled" \
+  "sudo sshd -T 2>/dev/null | grep -i '^permitrootlogin'" "no"
+check "PasswordAuthentication disabled" \
+  "sudo sshd -T 2>/dev/null | grep -i '^passwordauthentication'" "no"
+check "KbdInteractiveAuthentication disabled" \
+  "sudo sshd -T 2>/dev/null | grep -i '^kbdinteractiveauthentication'" "no"
+
+# --- Firewall ---
+echo ""
+echo "[Firewall]"
+check "UFW active" "sudo ufw status" "Status: active"
+check "UFW SSH rule" "sudo ufw status" "22/tcp"
+
+# --- Services ---
+echo ""
+echo "[Services]"
+check "fail2ban running" "systemctl is-active fail2ban" "active"
+check "unattended-upgrades active" "systemctl is-active unattended-upgrades" "active"
+check "ModemManager disabled" \
+  "systemctl is-enabled ModemManager 2>/dev/null || echo disabled" "disabled"
+check "multipathd disabled" \
+  "systemctl is-enabled multipathd 2>/dev/null || echo disabled" "disabled"
+
+# --- Users ---
+echo ""
+echo "[Users]"
+check "autonomys user exists" "id autonomys" "uid="
+check "sudoers entry (ubuntu->autonomys)" \
+  "sudo cat /etc/sudoers.d/ubuntu-to-autonomys" "ubuntu ALL=(autonomys) NOPASSWD: ALL"
+check "linger enabled for autonomys" \
+  "loginctl show-user autonomys -p Linger --value 2>/dev/null || echo no" "yes"
+check "autonomys SSH authorized_keys" \
+  "sudo test -f /home/autonomys/.ssh/authorized_keys && echo exists" "exists"
+
+# --- Node.js ---
+echo ""
+echo "[Node.js]"
+check "System Node.js installed" "/usr/bin/node --version" "v22"
+check "openclaw symlink exists" \
+  "ls -la /usr/local/bin/openclaw 2>/dev/null || echo missing" "/home/autonomys/.nvm"
+
+# --- journald ---
+echo ""
+echo "[Journald]"
+check "journald SystemMaxUse" \
+  "cat /etc/systemd/journald.conf.d/openclaw.conf" "SystemMaxUse=500M"
+check "journald MaxRetentionSec" \
+  "cat /etc/systemd/journald.conf.d/openclaw.conf" "MaxRetentionSec=30day"
+
+# --- fail2ban config ---
+echo ""
+echo "[fail2ban Config]"
+check "fail2ban bantime" "cat /etc/fail2ban/jail.local" "bantime"
+check "fail2ban maxretry" "cat /etc/fail2ban/jail.local" "maxretry = 5"
+
+# --- Unattended upgrades ---
+echo ""
+echo "[Unattended Upgrades]"
+check "Auto-reboot disabled" \
+  "cat /etc/apt/apt.conf.d/50unattended-upgrades-local" 'Automatic-Reboot "false"'
+
+# --- OpenClaw (as autonomys user) ---
+echo ""
+echo "[OpenClaw]"
+check "Gateway service running" \
+  "sudo -u autonomys XDG_RUNTIME_DIR=/run/user/\$(id -u autonomys) systemctl --user is-active openclaw-gateway" "active"
+check "EnvironmentFile override" \
+  "sudo -u autonomys XDG_RUNTIME_DIR=/run/user/\$(id -u autonomys) systemctl --user cat openclaw-gateway 2>/dev/null" "EnvironmentFile"
+check ".env exists" \
+  "sudo test -f /home/autonomys/.openclaw/.env && echo exists" "exists"
+check ".env permissions (600)" \
+  "sudo stat -c '%a' /home/autonomys/.openclaw/.env" "600"
+
+# --- Workspace ---
+echo ""
+echo "[Workspace]"
+check "SOUL.md" \
+  "sudo test -f /home/autonomys/.openclaw/workspace/SOUL.md && echo exists" "exists"
+check "HEARTBEAT.md" \
+  "sudo test -f /home/autonomys/.openclaw/workspace/HEARTBEAT.md && echo exists" "exists"
+check "Auto Drive skill" \
+  "sudo test -d /home/autonomys/.openclaw/workspace/skills/auto-drive && echo exists" "exists"
+
+# --- Cron ---
+echo ""
+echo "[Cron]"
+check "Disk check cron job" \
+  "crontab -l 2>/dev/null" "DISK WARNING"
+
+echo ""
+if [[ $ERRORS -eq 0 ]]; then
+  echo -e "=== Results: ${GREEN}$PASS passed${NC}, 0 failed ==="
+else
+  echo -e "=== Results: ${GREEN}$PASS passed${NC}, ${RED}$ERRORS failed${NC} ==="
+fi
+exit $ERRORS

--- a/resources/terraform/0xautonomys/variables.tf
+++ b/resources/terraform/0xautonomys/variables.tf
@@ -19,12 +19,13 @@ variable "region" {
 variable "vpc_id" {
   description = "VPC ID for the instance and security group"
   type        = string
+  default     = "vpc-0d170f772f1c56391"
 }
 
 variable "subnet_id" {
   description = "Subnet ID for the instance (leave empty to use first available default subnet)"
   type        = string
-  default     = ""
+  default     = "subnet-0c87d91f0d324335d"
 }
 
 variable "instance_type" {

--- a/resources/terraform/0xautonomys/variables.tf
+++ b/resources/terraform/0xautonomys/variables.tf
@@ -1,0 +1,58 @@
+variable "aws_access_key" {
+  description = "AWS access key"
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the instance and security group"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for the instance (leave empty to use first available default subnet)"
+  type        = string
+  default     = ""
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "volume_size" {
+  description = "Root EBS volume size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "key_name" {
+  description = "Name of the EC2 key pair (must already exist in AWS)"
+  type        = string
+  default     = "0xautonomys"
+}
+
+variable "ssh_allowed_cidrs" {
+  description = "CIDR blocks allowed SSH access (currently open due to no static IPs)"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "security_group_name" {
+  description = "Name of the security group"
+  type        = string
+  default     = "launch-wizard-4"
+}

--- a/resources/terraform/manage.sh
+++ b/resources/terraform/manage.sh
@@ -29,6 +29,7 @@ VALID_PROJECTS=(
   ["mainnet-reward-distributor"]="common.auto.tfvars"
   ["chronos-chain-indexer"]="common.auto.tfvars"
   ["mainnet-chain-indexer"]="common.auto.tfvars"
+  ["0xautonomys"]=""
 )
 
 # Allowed actions
@@ -39,7 +40,7 @@ function show_help() {
   echo "Valid projects:"
   for proj in "${!VALID_PROJECTS[@]}"; do
     echo "  - $proj"
-  done
+  done | sort
   echo "Valid actions:"
   for act in "${VALID_ACTIONS[@]}"; do
     echo "  - $act"
@@ -97,6 +98,10 @@ function validate_action() {
 # store secrets to infisical
 function store_secrets() {
   local files="${VALID_PROJECTS[$PROJECT]}"
+  if [[ -z "$files" ]]; then
+    echo "No secrets to store for project: $PROJECT"
+    return 0
+  fi
   echo "Storing secrets for project: $PROJECT"
   local file_args=()
   IFS=',' read -ra file_list <<< "$files"
@@ -117,6 +122,11 @@ function store_secrets() {
 
 # fetch secrets from infisical
 function fetch_secrets() {
+  local files="${VALID_PROJECTS[$PROJECT]}"
+  if [[ -z "$files" ]]; then
+    echo "No secrets to fetch for project: $PROJECT"
+    return 0
+  fi
   echo "Fetching secrets for project: $PROJECT"
 
   docker run -q --pull always --rm \

--- a/resources/terraform/manage.sh
+++ b/resources/terraform/manage.sh
@@ -29,7 +29,6 @@ VALID_PROJECTS=(
   ["mainnet-reward-distributor"]="common.auto.tfvars"
   ["chronos-chain-indexer"]="common.auto.tfvars"
   ["mainnet-chain-indexer"]="common.auto.tfvars"
-  ["0xautonomys"]="common.auto.tfvars"
 )
 
 # Allowed actions

--- a/resources/terraform/manage.sh
+++ b/resources/terraform/manage.sh
@@ -29,6 +29,7 @@ VALID_PROJECTS=(
   ["mainnet-reward-distributor"]="common.auto.tfvars"
   ["chronos-chain-indexer"]="common.auto.tfvars"
   ["mainnet-chain-indexer"]="common.auto.tfvars"
+  ["0xautonomys"]="common.auto.tfvars"
 )
 
 # Allowed actions


### PR DESCRIPTION
## Summary

- Adds Terraform project for the 0xAutonomys OpenClaw AI agent EC2 instance (us-east-2)
- Imports existing AWS resources (EC2, security group, EIP) into Terraform state with zero drift
- Includes cloud-init.yaml for OS-level reproducibility (SSH hardening, UFW, fail2ban, autonomys user, Node.js 22)
- Includes validate.sh for SSH-based OS configuration drift detection (31 checks)
- Registers project in manage.sh for Infisical secrets workflow

## What's automated vs manual

**Terraform manages:** EC2 instance, security group, Elastic IP

**cloud-init handles (first boot):** hostname, SSH hardening, UFW, fail2ban, unattended upgrades, service disabling, journald rotation, autonomys user, system Node.js 22

**Manual (documented in README):** nvm, OpenClaw installation/onboarding, .env secrets, systemd override, Telegram pairing, Google OAuth, workspace files, cron job
