### PR TITLE
Update Auto Drive RabbitMQ instance type

### DIFF
--- a/resources/terraform/auto-drive/variables.tf
+++ b/resources/terraform/auto-drive/variables.tf
@@ -131,7 +131,7 @@ variable "rabbitmq_replication_username" {
 variable "rabbitmq_instance_type" {
   description = "Instance type for RabbitMQ broker instances."
   type        = string
-  default     = "mq.t3.micro"
+  default     = "mq.m7g.medium"
 }
 
 variable "rabbitmq_version" {


### PR DESCRIPTION
AWS are retiring the `instance type Auto Drive currently uses for its RabbitMQ instance. Full details:

> ... you have one or more Amazon MQ for RabbitMQ brokers using hostInstanceType mq.t3.micro which will reach end support on October 1, 2026. Amazon MQ requires you to upgrade your broker hostInstanceType to mq.m7g by October 1, 2026. If your broker is not upgraded before the end of support date then Amazon MQ will isolate your broker and it will become unavailable. If you have not contacted Amazon MQ to recover your isolated mq.t3.micro broker before January 29, 2027 then your broker will be deleted without any possibility of recovery. Please migrate your broker to a supported instance type to avoid broker unavailability. Additionally, you will not be able to create new RabbitMQ brokers running on mq.t3.micro after April 1, 2026.

This PR updates the instance type from `mq.t3.micro` to `mq.m7g.medium`.