### PR TITLE
Upgrade RabbitMQ instance type from mq.t3.micro to mq.m7g.medium

### DIFF
--- a/resources/terraform/auto-drive-production/main.tf
+++ b/resources/terraform/auto-drive-production/main.tf
@@ -17,7 +17,7 @@ module "auto_drive" {
   }
 
   rabbitmq = {
-    instance_type   = "mq.t3.micro"
+    instance_type   = "mq.m7g.medium"
     version         = "3.13"
     deployment_mode = "SINGLE_INSTANCE"
     username        = var.rabbitmq_username


### PR DESCRIPTION
## Summary

- Upgrades the Auto Drive production RabbitMQ broker from `mq.t3.micro` to `mq.m7g.medium` in response to an AWS retirement notice
- `mq.m7g.medium` is a Graviton3-based instance type and AWS's recommended replacement for RabbitMQ brokers

## Why this change is safe to apply

### Data preservation
Amazon MQ for RabbitMQ uses **EBS-backed storage**. During an instance type change, AWS detaches the EBS volume from the old instance and reattaches it to the new one — durable queue definitions and persistent messages are preserved across the change. See [AWS: Editing a broker](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-editing-broker.html) and [Amazon MQ storage](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-broker-storage.html).

### Expected behaviour during apply
- The broker will restart as part of the instance replacement — a brief period of unavailability is expected
- This is a `SINGLE_INSTANCE` deployment with `apply_immediately = true`, so the change takes effect immediately (no maintenance window delay)
- Active client connections will drop and need to reconnect

### Application reconnection
The Auto Drive backend has a keepalive/reconnect mechanism (`keepAliveInterval`) that will detect the dropped connection and re-establish it automatically, typically within 60 seconds.

### Queue declarations
Queues in the Auto Drive app are declared with `assertQueue()` on each publish, so they are automatically re-created after the broker restarts. No manual intervention is required.

### References
- [Amazon MQ instance types for RabbitMQ](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-instance-types.html)
- [Editing a broker](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-editing-broker.html)
- [RabbitMQ storage on Amazon MQ](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-broker-storage.html)

## Test plan
- [x] Run `./resources/terraform/manage.sh auto-drive-production plan` and confirm only the broker instance type changes (1 resource, 0 destroy)
- [x] Apply during a low-traffic window
- [x] Confirm broker comes back healthy in the AWS Console (Amazon MQ → Brokers → status: RUNNING)
- [x] Confirm Auto Drive backend reconnects and resumes processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes https://github.com/autonomys/infra/issues/531.