### PR TITLE
Remove unused Infisical secrets config for auto-drive-production

### DIFF
--- a/resources/terraform/manage.sh
+++ b/resources/terraform/manage.sh
@@ -29,7 +29,7 @@ VALID_PROJECTS=(
   ["mainnet-reward-distributor"]="common.auto.tfvars"
   ["chronos-chain-indexer"]="common.auto.tfvars"
   ["mainnet-chain-indexer"]="common.auto.tfvars"
-  ["auto-drive-production"]="common.auto.tfvars"
+  ["auto-drive-production"]=""
   ["0xautonomys"]=""
 )
 


### PR DESCRIPTION
## Summary

- Sets `auto-drive-production` to `""` in the `VALID_PROJECTS` map in `manage.sh`, indicating no secrets to fetch or store
- Fixes a 404 error that occurred at the end of every `apply` when the script tried to store `common.auto.tfvars` to a non-existent Infisical path

## Why no secrets are needed

All variables in `auto-drive-production` have defaults (`region`, `backup_region`, `rabbitmq_username`) and AWS credentials are supplied via environment variables rather than a `common.auto.tfvars` file. There is no `common.auto.tfvars` in the project directory and none is required.

This matches the pattern used by `0xautonomys`, which is also configured with `""`.

## Related

- PR #533 — RabbitMQ instance type upgrade where this error was first observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)