### PR TITLE
Increase Auto Drive production RDS backup retention to 14 days

### DIFF
--- a/modules/auto-drive/broker.tf
+++ b/modules/auto-drive/broker.tf
@@ -40,6 +40,13 @@ resource "aws_mq_broker" "rabbitmq_broker_primary" {
   }
 
   tags = merge(local.tags, { Application = "AutoDrive" })
+
+  # The user block password is write-only — AWS never returns it in API responses,
+  # so Terraform cannot confirm it matches config after any in-place broker update.
+  # This causes perpetual drift on the user block; ignore_changes suppresses it.
+  lifecycle {
+    ignore_changes = [user]
+  }
 }
 
 resource "aws_security_group" "rabbitmq_broker_primary" {

--- a/modules/auto-drive/db.tf
+++ b/modules/auto-drive/db.tf
@@ -45,7 +45,7 @@ module "db" {
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   create_cloudwatch_log_group     = true
 
-  backup_retention_period = 3
+  backup_retention_period = var.database.backup_retention_period
   skip_final_snapshot     = true
   deletion_protection     = true
 

--- a/modules/auto-drive/variables.tf
+++ b/modules/auto-drive/variables.tf
@@ -47,11 +47,12 @@ variable "instances" {
 variable "database" {
   description = "RDS PostgreSQL configuration"
   type = object({
-    instance_class    = string
-    engine_version    = string
-    allocated_storage = number
-    max_storage       = number
-    multi_az          = bool
+    instance_class          = string
+    engine_version          = string
+    allocated_storage       = number
+    max_storage             = number
+    multi_az                = bool
+    backup_retention_period = optional(number, 3)
   })
 }
 

--- a/resources/terraform/auto-drive-production/main.tf
+++ b/resources/terraform/auto-drive-production/main.tf
@@ -35,10 +35,11 @@ module "auto_drive" {
   }
 
   database = {
-    instance_class    = "db.t4g.2xlarge"
-    engine_version    = "17.4"
-    allocated_storage = 50
-    max_storage       = 500
-    multi_az          = true
+    instance_class          = "db.t4g.2xlarge"
+    engine_version          = "17.4"
+    allocated_storage       = 50
+    max_storage             = 500
+    multi_az                = true
+    backup_retention_period = 14
   }
 }


### PR DESCRIPTION
## Summary

- Threads `backup_retention_period` through `modules/auto-drive` as an optional variable (default `3`, preserving existing behaviour for any future environments)
- Sets `backup_retention_period = 14` in `auto-drive-production` for longer point-in-time recovery coverage
- Adds `lifecycle { ignore_changes = [user] }` on the RabbitMQ broker to suppress perpetual state drift caused by the write-only password attribute not being returned by AWS after in-place broker updates (surfaced by the instance type upgrade in PR #533)

## Changes

- `modules/auto-drive/variables.tf` — adds `backup_retention_period` as optional attribute on `database` variable object
- `modules/auto-drive/db.tf` — wires `backup_retention_period` through to the RDS module call
- `resources/terraform/auto-drive-production/main.tf` — sets production-specific value of `14`
- `modules/auto-drive/broker.tf` — adds `lifecycle { ignore_changes = [user] }` to suppress RabbitMQ drift

## Test plan

- [x] `terraform plan` confirms only `backup_retention_period = 3 -> 14` on the RDS instance (1 change, 0 destroy)
- [x] `terraform apply` completed successfully — `db_instance_status = available`
- [x] RabbitMQ broker no longer appears as a pending change in the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)