### PR TITLE
autonomys.org: DKIM, SPF, DMARC

### DIFF
--- a/resources/terraform/dns/autonomys_org.tf
+++ b/resources/terraform/dns/autonomys_org.tf
@@ -29,6 +29,36 @@ resource "cloudflare_dns_record" "autonomys_org_www" {
   settings = {}
 }
 
+resource "cloudflare_dns_record" "autonomys_org_google_dkim" {
+  content  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk21qDpKceJPhmfMG9q2kbMnObBlPacoMQD7dM7eWLCMmL9HAWKLleUT3Cy8ORraz11yn3bxACTh48baVsYTVIBbAJBzHhgCjOsgd/EyJ3U2NXc3BXiYdpbNFWSIc5/GQnTVu9+ao1/hZC+0JCv/KaRlIFyUP7O7K+7c9naosWoTj/SvctzWpcUGdGXeRSYzJNaQpJQld5ZwR3yeCaEA4jV6M+M30nnv7zm4Sjqeo6pAvU5OlEsdWdp1ZGt17yNijdpEJiljqrru52DdnrxjqglY12dK+5c3XIXQptMWs4jOTbJCfdpMh8NDE2IPS9PH3W10vQ95K0PeH8Bm8bmrcIwIDAQAB"
+  name     = "google-org._domainkey.autonomys.org"
+  proxied  = false
+  ttl      = 1
+  type     = "TXT"
+  zone_id  = data.cloudflare_zone.autonomys_org.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "autonomys_org_spf" {
+  content  = "v=spf1 include:_spf.google.com include:subspace.network include:49004947.spf07.hubspotemail.net -all"
+  name     = "autonomys.org"
+  proxied  = false
+  ttl      = 1
+  type     = "TXT"
+  zone_id  = data.cloudflare_zone.autonomys_org.zone_id
+  settings = {}
+}
+
+resource "cloudflare_dns_record" "autonomys_org_dmarc" {
+  content  = "v=DMARC1; p=reject; pct=50; rua=mailto:admin@autonomys.org; ruf=mailto:admin@autonomys.org; aspf=r; adkim=r;"
+  name     = "_dmarc.autonomys.org"
+  proxied  = false
+  ttl      = 1
+  type     = "TXT"
+  zone_id  = data.cloudflare_zone.autonomys_org.zone_id
+  settings = {}
+}
+
 resource "cloudflare_ruleset" "autonomys_org_redirect_to_xyz" {
   zone_id     = data.cloudflare_zone.autonomys_org.zone_id
   name        = "Redirect autonomys.org to autonomys.xyz"

--- a/resources/terraform/dns/autonomys_org.tf
+++ b/resources/terraform/dns/autonomys_org.tf
@@ -40,7 +40,7 @@ resource "cloudflare_dns_record" "autonomys_org_google_dkim" {
 }
 
 resource "cloudflare_dns_record" "autonomys_org_spf" {
-  content  = "v=spf1 include:_spf.google.com include:subspace.network include:49004947.spf07.hubspotemail.net -all"
+  content  = "v=spf1 include:_spf.google.com -all"
   name     = "autonomys.org"
   proxied  = false
   ttl      = 1


### PR DESCRIPTION
## Summary
Adds outbound email-auth records for `autonomys.org` so mail sent from `@autonomys.org` passes SPF/DKIM/DMARC alignment.

- **DKIM** at `google-org._domainkey.autonomys.org` — public key generated by Google Workspace admin for the .org domain.
- **SPF** at apex — minimal Google-only: `v=spf1 include:_spf.google.com -all`. Dropped the `include:subspace.network` and `include:49004947.spf07.hubspotemail.net` mechanisms that autonomys.xyz carries; subspace.network's SPF is itself just `include:_spf.google.com -all` (no-op redundancy), and the HubSpot include only matters once HubSpot is wired up for .org.
- **DMARC** at `_dmarc.autonomys.org` — same policy shape as autonomys.xyz (`p=reject; pct=50; aspf=r; adkim=r`), reports go to `admin@autonomys.org`.

## Why
Inbound MX landed in #536/#537. Without SPF/DKIM/DMARC, mail sent FROM `@autonomys.org` would fail recipient deliverability checks (Gmail, Microsoft, etc. flag or drop unsigned mail).

## Diff against autonomys.xyz pattern (intentional)
| Record | autonomys.xyz | autonomys.org (this PR) | Reason for divergence |
|---|---|---|---|
| SPF | `+ include:subspace.network`, `+ include:49004947.spf07.hubspotemail.net` | dropped both | subspace.network is no-op redundancy; HubSpot only relevant once HubSpot is configured for .org |
| DMARC rua/ruf | `admin@autonomys.xyz` | `admin@autonomys.org` | per-domain reporting |
| DKIM selector | `google` | `google-org` | as generated by Workspace admin for .org |

## Follow-ups (out of scope for this PR)
- google-site-verification TXTs (per-service, generated when each Google product enrolls .org)
- HubSpot DKIM CNAMEs (`hs1-<id>` / `hs2-<id>`) — only when HubSpot is configured for .org
- SendGrid records on `mail.autonomys.org` — only if SendGrid is configured for .org
- DMARC reports inbox: confirm `admin@autonomys.org` is a real inbox/group in the new Workspace, otherwise reports bounce

## Test plan
- [ ] `manage.sh dns plan` shows 3 to add, 0 to change, 0 to destroy
- [ ] `manage.sh dns apply` succeeds
- [ ] `dig +short TXT google-org._domainkey.autonomys.org @8.8.8.8` returns the DKIM key
- [ ] `dig +short TXT autonomys.org @8.8.8.8 | grep spf1` returns the simplified SPF
- [ ] `dig +short TXT _dmarc.autonomys.org @8.8.8.8` returns the DMARC policy