### PR TITLE
Relax Email Authentication Policies for autonomys.org Warm-up

### DIFF
--- a/resources/terraform/dns/autonomys_org.tf
+++ b/resources/terraform/dns/autonomys_org.tf
@@ -40,7 +40,7 @@ resource "cloudflare_dns_record" "autonomys_org_google_dkim" {
 }
 
 resource "cloudflare_dns_record" "autonomys_org_spf" {
-  content  = "v=spf1 include:_spf.google.com -all"
+  content  = "v=spf1 include:_spf.google.com ~all"
   name     = "autonomys.org"
   proxied  = false
   ttl      = 1
@@ -50,7 +50,7 @@ resource "cloudflare_dns_record" "autonomys_org_spf" {
 }
 
 resource "cloudflare_dns_record" "autonomys_org_dmarc" {
-  content  = "v=DMARC1; p=reject; pct=50; rua=mailto:admin@autonomys.org; ruf=mailto:admin@autonomys.org; aspf=r; adkim=r;"
+  content  = "v=DMARC1; p=none; rua=mailto:admin@autonomys.org; ruf=mailto:admin@autonomys.org; aspf=r; adkim=r;"
   name     = "_dmarc.autonomys.org"
   proxied  = false
   ttl      = 1


### PR DESCRIPTION
## Summary

This PR updates the DNS records for `autonomys.org` to support an upcoming email domain warm-up. We are shifting from a strict enforcement posture to a monitoring/testing posture to prevent legitimate emails from being blocked while we establish the domain's reputation and finalize DKIM alignment.

## Changes

### 1. SPF Record Update

**Record:** `autonomys.org`
**Change:** Updated the failure mechanism from "Hard Fail" (`-all`) to "Soft Fail" (`~all`).
**Rationale:** During the warm-up phase, a "Soft Fail" prevents receiving servers from flat-out rejecting emails that might encounter minor delivery issues. This protects our delivery rate while we scale volume.

### 2. DMARC Policy Update

**Record:** `_dmarc.autonomys.org`
**Change:** Updated policy from `p=reject; pct=50` to `p=none`.
**Rationale:** Our previous aggregate reports showed DKIM alignment failures because mail was being signed by the primary `subspace.network` key. While we have now activated the specific `autonomys.org` DKIM key in Google Admin, moving to `p=none` allows us to monitor the next 24-48 hours of traffic without the risk of 50% of our mail being rejected.