### PR TITLE
Bump chain-alerter and chain-indexer to v1.2.0

### DIFF
--- a/resources/terraform/chronos-chain-alerter/main.tf
+++ b/resources/terraform/chronos-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "chronos_chain_alerter" {
 
   instance = {
     network_name               = "chronos"
-    docker_tag                 = "sha-e11743aa09588695f993c23dcda91d8a0382d282"
+    docker_tag                 = "v1.2.0"
     instance_type              = "c3.xlarge"
     rpc_url                    = "wss://rpc.chronos.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/chronos-chain-indexer/main.tf
+++ b/resources/terraform/chronos-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "chronos_chain_indexer" {
   instance = {
     network_name               = "chronos"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "sha-e11743aa09588695f993c23dcda91d8a0382d282"
+    docker_tag                 = "v1.2.0"
     instance_type              = "c3.xlarge"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"

--- a/resources/terraform/chronos-chain-indexer/main.tf
+++ b/resources/terraform/chronos-chain-indexer/main.tf
@@ -28,7 +28,7 @@ module "chronos_chain_indexer" {
     consensus_rpc              = "wss://rpc.chronos.autonomys.xyz/ws"
     auto_evm_rpc               = "wss://auto-evm.chronos.autonomys.xyz/ws"
     db_password                = var.db_password
-    process_blocks_in_parallel = 400
+    process_blocks_in_parallel = 50
   }
 
   cloudflare_api_token = var.cloudflare_api_token

--- a/resources/terraform/mainnet-chain-alerter/main.tf
+++ b/resources/terraform/mainnet-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "mainnet_chain_alerter" {
 
   instance = {
     network_name               = "mainnet"
-    docker_tag                 = "sha-e11743aa09588695f993c23dcda91d8a0382d282"
+    docker_tag                 = "v1.2.0"
     instance_type              = "c3.xlarge"
     rpc_url                    = "wss://rpc.mainnet.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/mainnet-chain-indexer/main.tf
+++ b/resources/terraform/mainnet-chain-indexer/main.tf
@@ -28,7 +28,7 @@ module "mainnet_chain_indexer" {
     consensus_rpc              = "wss://rpc.mainnet.autonomys.xyz/ws"
     auto_evm_rpc               = "wss://auto-evm.mainnet.autonomys.xyz/ws"
     db_password                = var.db_password
-    process_blocks_in_parallel = 400
+    process_blocks_in_parallel = 50
   }
 
   cloudflare_api_token = var.cloudflare_api_token

--- a/resources/terraform/mainnet-chain-indexer/main.tf
+++ b/resources/terraform/mainnet-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "mainnet_chain_indexer" {
   instance = {
     network_name               = "mainnet"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "sha-e11743aa09588695f993c23dcda91d8a0382d282"
+    docker_tag                 = "v1.2.0"
     instance_type              = "c3.xlarge"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"


### PR DESCRIPTION
## Summary
- Bumps `docker_tag` to `v1.2.0` for chain-alerter and chain-indexer across mainnet and chronos. Images: `ghcr.io/autonomys/chain-alerter:v1.2.0`, `ghcr.io/autonomys/chain-indexer:v1.2.0`.
- Aligns `process_blocks_in_parallel` on both indexer projects to `50`, matching the live deployed value (drift fix — `main` had `400` from an older commit that was never applied; the `indexer_update` branch had been used for the last apply with `50`).