### PR TITLE
Roll chronos to chronos-2026-apr-30 (tk-1, rolling non-tk, then tk-0)

### DIFF
--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -39,7 +39,7 @@ module "chronos" {
     enable-load-balancer = true
     rpc-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -94,7 +94,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -76,7 +76,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -21,7 +21,7 @@ module "chronos" {
     genesis-hash = "91912b429ce7bf2975440a0920b46a892fddeeaed6ccc11c93f2d57ad1bd69ab"
     bootstrap-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -120,7 +120,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 1
         operator-id   = 1

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -50,7 +50,7 @@ module "chronos" {
   timekeeper-node-config = {
     timekeeper-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -56,6 +56,14 @@ module "chronos" {
         sync-mode     = "full"
         ipv4          = var.timekeeper_node_ipv4.timekeeper-0
         cpu-cores     = "8-11"
+      },
+      {
+        docker-tag    = "chronos-2026-apr-30"
+        reserved-only = false
+        index         = 1
+        sync-mode     = "snap"
+        ipv4          = var.timekeeper_node_ipv4.timekeeper-1
+        cpu-cores     = "8-11"
       }
     ]
   }

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -111,7 +111,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         operator-id   = 0

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -61,7 +61,7 @@ module "chronos" {
         docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 1
-        sync-mode     = "snap"
+        sync-mode     = "full"
         ipv4          = var.timekeeper_node_ipv4.timekeeper-1
         cpu-cores     = "8-11"
       }


### PR DESCRIPTION
Rolling chronos to chronos-2026-apr-30.

I added a second timekeeper at 192.240.203.155 (pnap, same i9-14900K SKU as the existing one) so we have a redundant PoT producer before touching tk-0. It's on the new image already, fully synced and producing PoT alongside tk-0. Snap sync didn't work — chronos doesn't have enough peers serving snap data — so it ended up on full sync, which took a day to catch up.

Now bumping the rest of the chronos nodes to chronos-2026-apr-30 in the same PR, one at a time so we can catch any regression early: rpc, domain rpc, domain bootstrap, both auto-evm operators, then the consensus bootstrap on Hetzner. tk-0 is the very last step and I'm holding it for explicit confirmation — if tk-1 turns out not to be producing for some reason we missed, taking tk-0 down would stall the chain.

Changes since mainnet-2026-feb-28: PoS table backport from Abundance (~30-40% faster), polkadot-sdk stable2503 → 2512, rust nightly bump.