### PR TITLE
Roll chronos non-tk nodes to chronos-2026-apr-30

### DIFF
--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -39,7 +39,7 @@ module "chronos" {
     enable-load-balancer = true
     rpc-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "chronos-2026-apr-30"
         reserved-only = false
         index         = 0
         sync-mode     = "full"


### PR DESCRIPTION
## Summary
Rolling upgrade of all chronos non-timekeeper nodes from `mainnet-2026-feb-28` to `chronos-2026-apr-30`. Each commit bumps one node; applied + verified before the next commit. tk-0 is **deliberately excluded** — it is the last step and gated on explicit confirmation.

Order (lowest-risk → highest):
1. consensus-rpc-node (rpc.chronos.autonomys.xyz)
2. domain-rpc-node (auto-evm.chronos.autonomys.xyz)
3. domain-bootstrap-node
4. domain-operator-node[0]
5. domain-operator-node[1]
6. bare-consensus-bootstrap-node (Hetzner 65.108.232.15)
7. **STOP — confirm before tk-0**

Base branch is `chronos/timekeeper-1` (PR #541) so tk-1 stays in state. After #541 merges, this PR's base auto-retargets to `main`.