### PR TITLE
Bump chain-indexer + chain-alerter to v1.2.1

### DIFF
--- a/resources/terraform/chronos-chain-alerter/main.tf
+++ b/resources/terraform/chronos-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "chronos_chain_alerter" {
 
   instance = {
     network_name               = "chronos"
-    docker_tag                 = "v1.2.0"
+    docker_tag                 = "v1.2.1"
     instance_type              = "c3.xlarge"
     rpc_url                    = "wss://rpc.chronos.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/chronos-chain-indexer/main.tf
+++ b/resources/terraform/chronos-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "chronos_chain_indexer" {
   instance = {
     network_name               = "chronos"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "v1.2.0"
+    docker_tag                 = "v1.2.1"
     instance_type              = "c3.xlarge"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"

--- a/resources/terraform/mainnet-chain-alerter/main.tf
+++ b/resources/terraform/mainnet-chain-alerter/main.tf
@@ -20,7 +20,7 @@ module "mainnet_chain_alerter" {
 
   instance = {
     network_name               = "mainnet"
-    docker_tag                 = "v1.2.0"
+    docker_tag                 = "v1.2.1"
     instance_type              = "c3.xlarge"
     rpc_url                    = "wss://rpc.mainnet.autonomys.xyz/ws"
     uptimekuma_url             = var.uptimekuma_url

--- a/resources/terraform/mainnet-chain-indexer/main.tf
+++ b/resources/terraform/mainnet-chain-indexer/main.tf
@@ -21,7 +21,7 @@ module "mainnet_chain_indexer" {
   instance = {
     network_name               = "mainnet"
     domain_fqdn                = "autonomys.xyz"
-    docker_tag                 = "v1.2.0"
+    docker_tag                 = "v1.2.1"
     instance_type              = "c3.xlarge"
     disk_volume_size           = 500
     disk_volume_type           = "gp3"


### PR DESCRIPTION
v1.2.1 fixes the startup hang where `Subspace::new_from_url` could block indefinitely if the substrate RPC was unreachable at the moment of connect — the bug that caused the mainnet chain-indexer to zombie for 41 hours on May 6 (502s on `staking.autonomys.xyz`). The fix wraps the call in a 60s `tokio::time::timeout` in `shared/src/subspace.rs` so both indexer and alerter binaries pick it up. Upstream PR: autonomys/chain-pulse#117.

Rolling chronos first, then mainnet, with a verify pass on each container before moving to the next.