### PR TITLE
Format auto-drive db module assignment block

### DIFF
--- a/modules/auto-drive/db.tf
+++ b/modules/auto-drive/db.tf
@@ -19,10 +19,10 @@ module "db" {
   engine_version              = var.database.engine_version
   engine_lifecycle_support    = "open-source-rds-extended-support-disabled"
   allow_major_version_upgrade = false
-  family               = local.db_family
-  major_engine_version = local.db_major_version
-  instance_class       = var.database.instance_class
-  apply_immediately    = true
+  family                      = local.db_family
+  major_engine_version        = local.db_major_version
+  instance_class              = var.database.instance_class
+  apply_immediately           = true
 
   allocated_storage     = var.database.allocated_storage
   max_allocated_storage = var.database.max_storage


### PR DESCRIPTION
Ran terraform fmt on modules/auto-drive/db.tf. The assignment block in the db module had misaligned = signs, which I noticed while reviewing the Postgres bump. Pure formatting, no behavior change.