### PR TITLE
Cap reward-distributor container logs

### DIFF
--- a/modules/operator-reward-distributor/docker-compose.yml
+++ b/modules/operator-reward-distributor/docker-compose.yml
@@ -19,8 +19,12 @@ services:
       - .env
     environment:
       SCHEDULER_HOST: 0.0.0.0
-      LOG_FILE_PATH: /data/logs/reward_distributor_scheduler.log
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     depends_on:
       init-perms:
         condition: service_completed_successfully
@@ -43,8 +47,12 @@ services:
     environment:
       SCHEDULER_HEALTH_URL: http://scheduler:3000/
       SERVER_HOST: 0.0.0.0
-      LOG_FILE_PATH: /data/logs/reward_distributor_api.log
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     depends_on:
       init-perms:
         condition: service_completed_successfully
@@ -72,5 +80,10 @@ services:
     ports:
       - "80:80"
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - reward-distributor

--- a/modules/operator-reward-distributor/instances.tf
+++ b/modules/operator-reward-distributor/instances.tf
@@ -69,8 +69,14 @@ resource "null_resource" "setup_reward_distributor_node" {
 resource "null_resource" "start_reward_distributor_node" {
   depends_on = [null_resource.setup_reward_distributor_node]
 
-  # trigger node re-deployment if anything changes in the node config
-  triggers = var.instance
+  # trigger node re-deployment if the node config or the deployed files change
+  triggers = merge(
+    var.instance,
+    {
+      compose_sha = filesha256(var.deployer.path_to_docker_compose)
+      nginx_sha   = filesha256(var.deployer.path_to_nginx_conf)
+    }
+  )
 
   connection {
     host           = aws_instance.reward_distributor_node.public_ip


### PR DESCRIPTION
The mainnet reward-distributor halted emissions for ~3 days last week because its host disk filled to 100%. The container logs were the cause: the json-file driver had no size cap so it grew unbounded (api alone was 1.5G), and the app also double-writes the same lines to /data/logs via LOG_FILE_PATH (another 1.1G on the same 7.6G disk).

Two changes:
- Cap json-file logging at 10m x 3 on scheduler, api and proxy, and drop LOG_FILE_PATH so logs flow only through the capped stdout driver instead of a second uncapped file. One bounded log sink.
- The deploy step only re-triggered on instance config changes, not on the compose/nginx files, so a compose-only edit wouldn't actually deploy. Added a filesha256 of both files to the trigger, so this change and future ones deploy on a normal apply.

Applying recreates the containers (docker compose down && up -d), so expect a brief emission gap of about a minute. Leaving as a draft until it's applied and verified.

The app-side gap (the emission loop hung silently instead of failing when writes started failing, so the restart policy never recovered it) is tracked in subspace/operator-reward-distributor#12.