### PR TITLE
Roll chronos nodes to chronos-2026-jun-01

### DIFF
--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -50,7 +50,7 @@ module "chronos" {
   timekeeper-node-config = {
     timekeeper-nodes = [
       {
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -109,7 +109,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 0
         operator-id   = 0

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -92,7 +92,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -118,7 +118,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 1
         operator-id   = 1

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -74,7 +74,7 @@ module "chronos" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -57,7 +57,7 @@ module "chronos" {
         ipv4          = var.timekeeper_node_ipv4.timekeeper-0
       },
       {
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 1
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -39,7 +39,7 @@ module "chronos" {
     enable-load-balancer = true
     rpc-nodes = [
       {
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/chronos/main.tf
+++ b/resources/terraform/chronos/main.tf
@@ -21,7 +21,7 @@ module "chronos" {
     genesis-hash = "91912b429ce7bf2975440a0920b46a892fddeeaed6ccc11c93f2d57ad1bd69ab"
     bootstrap-nodes = [
       {
-        docker-tag    = "chronos-2026-apr-30"
+        docker-tag    = "chronos-2026-jun-01"
         reserved-only = false
         index         = 0
         sync-mode     = "full"


### PR DESCRIPTION
Rolls all 8 chronos nodes from chronos-2026-apr-30 to chronos-2026-jun-01 (security deps plus minor infra; chronos is already past the mar-09 mandatory changes). One commit per node so the staged rollout maps one-to-one.

Applying node by node with -target. A bare plan wants to replace both timekeepers at once (leftover cpu-cores drift from the cpu-tuning refactor), so each apply is scoped to a single node and the two timekeepers go one at a time, keeping PoT production up throughout. Marking ready once every node is verified on the new tag.