### PR TITLE
Roll mainnet nodes to mainnet-2026-jun-08

### DIFF
--- a/resources/terraform/mainnet-consensus/main.tf
+++ b/resources/terraform/mainnet-consensus/main.tf
@@ -51,7 +51,7 @@ module "mainnet_consensus" {
   timekeeper-node-config = {
     timekeeper-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/mainnet-consensus/main.tf
+++ b/resources/terraform/mainnet-consensus/main.tf
@@ -22,7 +22,7 @@ module "mainnet_consensus" {
     genesis-hash = "66455a580aabff303720aa83adbe6c44502922251c03ba73686d5245da9e21bd"
     bootstrap-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/mainnet-consensus/main.tf
+++ b/resources/terraform/mainnet-consensus/main.tf
@@ -40,7 +40,7 @@ module "mainnet_consensus" {
     disk-volume-type     = "gp3"
     rpc-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -58,7 +58,7 @@ module "mainnet_domains" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         operator-id   = 0

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -91,7 +91,7 @@ module "mainnet_domains" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 3
         operator-id   = 3

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -22,7 +22,7 @@ module "mainnet_domains" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -81,7 +81,7 @@ module "mainnet_domains" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 2
         operator-id   = 2

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -67,7 +67,7 @@ module "mainnet_domains" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 1
         operator-id   = 1

--- a/resources/terraform/mainnet-domains/main.tf
+++ b/resources/terraform/mainnet-domains/main.tf
@@ -41,7 +41,7 @@ module "mainnet_domains" {
       {
         domain-id     = 0
         domain-name   = "auto-evm"
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/mainnet-foundation/main.tf
+++ b/resources/terraform/mainnet-foundation/main.tf
@@ -29,7 +29,7 @@ module "mainnet_foundation" {
     enable-load-balancer = true
     rpc-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"

--- a/resources/terraform/mainnet-foundation/main.tf
+++ b/resources/terraform/mainnet-foundation/main.tf
@@ -14,7 +14,7 @@ module "mainnet_foundation" {
     genesis-hash = "66455a580aabff303720aa83adbe6c44502922251c03ba73686d5245da9e21bd"
     bootstrap-nodes = [
       {
-        docker-tag    = "mainnet-2026-feb-28"
+        docker-tag    = "mainnet-2026-jun-08"
         reserved-only = false
         index         = 0
         sync-mode     = "full"


### PR DESCRIPTION
Rolls all 11 mainnet nodes from mainnet-2026-feb-28 to mainnet-2026-jun-08 across the three mainnet projects (consensus 3, domains 6, foundation 2), one commit per node. jun-08 catches us up past the mar-09 mandatory client release we'd been running behind, and brings polkadot-sdk stable2512, farmer hardening, and security deps.

Applying node by node with -target (bootstraps, then RPCs, then operators, timekeeper last). After the domain-rpc restart I check the reward-distributor health since it can wedge on a WS drop, and after the consensus-rpc restarts I check the chain-indexer and alerter reconnect. Marking ready once every node is verified on jun-08.