### PR TITLE
Remove transient region2 provider plumbing for auto-drive

### DIFF
--- a/modules/auto-drive/provider.tf
+++ b/modules/auto-drive/provider.tf
@@ -5,10 +5,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-      # region2 alias retained transiently so Terraform can destroy
-      # orphaned KMS and backup-replication resources in us-west-1.
-      # Remove this alias once those orphans are gone from state.
-      configuration_aliases = [aws.region2]
     }
     random = {
       source  = "hashicorp/random"

--- a/resources/terraform/auto-drive-production/main.tf
+++ b/resources/terraform/auto-drive-production/main.tf
@@ -2,8 +2,7 @@ module "auto_drive" {
   source = "../../../modules/auto-drive"
 
   providers = {
-    aws         = aws
-    aws.region2 = aws.region2
+    aws = aws
   }
 
   environment = "prod"

--- a/resources/terraform/auto-drive-production/providers.tf
+++ b/resources/terraform/auto-drive-production/providers.tf
@@ -4,17 +4,6 @@ provider "aws" {
   secret_key = var.aws_secret_key
 }
 
-# Retained transiently to let Terraform destroy orphaned KMS + RDS
-# backup-replication resources in us-west-1. Once those are gone from
-# state, remove this alias, the backup_region variable, and the
-# aws.region2 passthrough in main.tf.
-provider "aws" {
-  alias      = "region2"
-  region     = var.backup_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-}
-
 provider "aws" {
   alias      = "auth"
   region     = var.auth_region

--- a/resources/terraform/auto-drive-production/variables.tf
+++ b/resources/terraform/auto-drive-production/variables.tf
@@ -16,14 +16,6 @@ variable "region" {
   default     = "us-west-2"
 }
 
-# Retained transiently so the region2 provider alias resolves while
-# Terraform destroys orphaned cross-region backup-replication resources.
-variable "backup_region" {
-  description = "AWS region for orphaned RDS cross-region backup replication (transient; remove after destroy)"
-  type        = string
-  default     = "us-west-1"
-}
-
 ################################################################################
 # Auth Lambda
 ################################################################################


### PR DESCRIPTION
## Summary

Follow-up to #550. Removes the transient `region2` provider alias and its supporting variable/passthrough now that the orphan KMS and backup-replication resources have been destroyed from state.

Refs #524.

## Background

#550 had to retain the `region2` provider alias temporarily because Terraform refuses to plan a destroy for a resource whose provider configuration has been removed. With the destroy applied and confirmed (`terraform plan` returns "No changes" against `auto-drive-production`), the alias is no longer referenced by anything and can be removed.

## Changes

- `modules/auto-drive/provider.tf` — drop `configuration_aliases = [aws.region2]`
- `resources/terraform/auto-drive-production/providers.tf` — drop the `region2` aws provider block
- `resources/terraform/auto-drive-production/variables.tf` — drop the `backup_region` variable
- `resources/terraform/auto-drive-production/main.tf` — drop the `aws.region2 = aws.region2` passthrough in the module call

## Test plan

- [x] `manage.sh auto-drive-production plan` returns "No changes. Your infrastructure matches the configuration." — **any resource diff means stop and investigate.**
- [x] Review + approve
- [x] Merge + apply (no-op apply for completeness)
- [x] Close #524 once applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)